### PR TITLE
Add initial Python rosmsg port

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,18 @@
+name: Python
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install -e ".[dev]"
+      - run: pre-commit run --files $(git ls-files '*.py')
+      - run: python -m pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-pyproject]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rosmsg"
+version = "0.1.0"
+description = "Python implementation of rosmsg tools"
+readme = "README.md"
+requires-python = ">=3.10"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "pre-commit",
+]
+
+[tool.isort]
+profile = "black"
+
+[tool.black]
+line-length = 88
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203"]
+per-file-ignores = ["python_ros/tests/test_md5.py: E501"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+
+[tool.setuptools.packages.find]
+where = ["python_ros"]

--- a/python_ros/README.md
+++ b/python_ros/README.md
@@ -1,0 +1,30 @@
+# Python ROS Packages
+
+This directory contains Python ports of selected ROS utilities.
+
+## Setup
+
+Use a virtual environment with Python 3.10 or newer, then install the project in editable mode with its development dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+```
+
+## Pre-commit hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to run code quality checks:
+
+```bash
+pre-commit install
+pre-commit run --files $(git ls-files '*.py')
+```
+
+## Testing
+
+Run the unit tests with `pytest`:
+
+```bash
+pytest
+```

--- a/python_ros/__init__.py
+++ b/python_ros/__init__.py
@@ -1,0 +1,3 @@
+"""Python ports of ROS utilities."""
+
+__all__ = []

--- a/python_ros/message_definition/__init__.py
+++ b/python_ros/message_definition/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+
+@dataclass
+class MessageDefinitionField:
+    type: str
+    name: str
+    is_array: bool = False
+    array_length: Optional[int] = None
+    is_constant: bool = False
+    value: Any = None
+    value_text: Optional[str] = None
+    is_complex: bool = False
+
+
+@dataclass
+class MessageDefinition:
+    name: Optional[str]
+    definitions: List[MessageDefinitionField]
+
+
+def is_msg_def_equal(a: MessageDefinition, b: MessageDefinition) -> bool:
+    return a == b

--- a/python_ros/rosmsg/__init__.py
+++ b/python_ros/rosmsg/__init__.py
@@ -1,0 +1,4 @@
+from .md5 import md5
+from .parse import fixup_types, normalize_type, parse
+
+__all__ = ["parse", "fixup_types", "normalize_type", "md5"]

--- a/python_ros/rosmsg/md5.py
+++ b/python_ros/rosmsg/md5.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Dict, List
+
+from ..message_definition import MessageDefinition
+
+BUILTIN_TYPES = {
+    "int8",
+    "uint8",
+    "int16",
+    "uint16",
+    "int32",
+    "uint32",
+    "int64",
+    "uint64",
+    "float32",
+    "float64",
+    "string",
+    "bool",
+    "char",
+    "byte",
+    "time",
+    "duration",
+}
+
+
+def md5(msg_defs: List[MessageDefinition]) -> str:
+    if not msg_defs:
+        raise ValueError("Cannot produce md5sum for empty msgDefs")
+    sub_defs: Dict[str, MessageDefinition] = {
+        d.name: d for d in msg_defs if d.name is not None
+    }
+    first = msg_defs[0]
+    return _compute_md5(first, sub_defs)
+
+
+def _compute_md5(
+    msg_def: MessageDefinition, sub_defs: Dict[str, MessageDefinition]
+) -> str:
+    constants = [d for d in msg_def.definitions if d.is_constant]
+    variables = [d for d in msg_def.definitions if not d.is_constant]
+    lines: List[str] = []
+    for d in constants:
+        value_text = d.value_text if d.value_text is not None else str(d.value)
+        lines.append(f"{d.type} {d.name}={value_text}")
+    for d in variables:
+        if _is_builtin(d.type):
+            array_len = str(d.array_length) if d.array_length is not None else ""
+            array = f"[{array_len}]" if d.is_array else ""
+            lines.append(f"{d.type}{array} {d.name}")
+        else:
+            sub = sub_defs.get(d.type)
+            if sub is None:
+                raise ValueError(f'Missing definition for submessage type "{d.type}"')
+            sub_md5 = _compute_md5(sub, sub_defs)
+            lines.append(f"{sub_md5} {d.name}")
+    text = "\n".join(lines)
+    return hashlib.md5(text.encode()).hexdigest()
+
+
+def _is_builtin(type_name: str) -> bool:
+    return type_name in BUILTIN_TYPES

--- a/python_ros/rosmsg/parse.py
+++ b/python_ros/rosmsg/parse.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import re
+from typing import List, Optional
+
+from ..message_definition import (
+    MessageDefinition,
+    MessageDefinitionField,
+    is_msg_def_equal,
+)
+
+BUILTIN_TYPES = {
+    "int8",
+    "uint8",
+    "int16",
+    "uint16",
+    "int32",
+    "uint32",
+    "int64",
+    "uint64",
+    "float32",
+    "float64",
+    "string",
+    "bool",
+    "char",
+    "byte",
+    "time",
+    "duration",
+}
+
+
+def parse(
+    message_definition: str, ros2: bool = False, skip_type_fixup: bool = False
+) -> List[MessageDefinition]:
+    if ros2:
+        raise NotImplementedError("ROS2 parsing not yet implemented")
+
+    lines = [line.strip() for line in message_definition.splitlines() if line.strip()]
+    definition_lines: List[str] = []
+    types: List[MessageDefinition] = []
+    for line in lines:
+        if line.startswith("#"):
+            continue
+        if line.startswith("=="):
+            types.append(_build_type(definition_lines))
+            definition_lines = []
+        else:
+            definition_lines.append(line)
+    types.append(_build_type(definition_lines))
+
+    unique: List[MessageDefinition] = []
+    for t in types:
+        if not any(is_msg_def_equal(t, other) for other in unique):
+            unique.append(t)
+
+    if not skip_type_fixup:
+        fixup_types(unique)
+
+    return unique
+
+
+def fixup_types(types: List[MessageDefinition]) -> None:
+    for msg in types:
+        namespace = "/".join(msg.name.split("/")[:-1]) if msg.name else None
+        for field in msg.definitions:
+            if field.is_complex:
+                found = _find_type_by_name(types, field.type, namespace)
+                if found.name is None:
+                    raise ValueError(f"Missing type definition for {field.type}")
+                field.type = found.name
+
+
+def _build_type(lines: List[str]) -> MessageDefinition:
+    definitions: List[MessageDefinitionField] = []
+    complex_type_name: Optional[str] = None
+    for line in lines:
+        if line.startswith("MSG:"):
+            complex_type_name = line.split(":", 1)[1].strip()
+            continue
+        line = re.sub(r"#.*", "", line).strip()
+        if not line:
+            continue
+        m = re.match(
+            r"(?P<type>[^\s]+)\s+(?P<name>[^\s=]+)(\s*=\s*(?P<value>.*))?", line
+        )
+        if not m:
+            raise ValueError(f"Could not parse line: '{line}'")
+        type_name = normalize_type(m.group("type"))
+        name = m.group("name")
+        value_text = m.group("value")
+        is_array = False
+        array_length: Optional[int] = None
+        array_match = re.match(r"^(?P<base>[^\[]+)\[(?P<len>\d*)\]$", type_name)
+        if array_match:
+            type_name = array_match.group("base")
+            is_array = True
+            length = array_match.group("len")
+            if length:
+                array_length = int(length)
+        is_complex = not _is_builtin(type_name)
+        field = MessageDefinitionField(
+            type=type_name,
+            name=name,
+            is_array=is_array,
+            array_length=array_length,
+            is_constant=value_text is not None,
+            value_text=value_text.strip() if value_text is not None else None,
+            is_complex=is_complex,
+        )
+        definitions.append(field)
+    return MessageDefinition(name=complex_type_name, definitions=definitions)
+
+
+def _find_type_by_name(
+    types: List[MessageDefinition], name: str, type_namespace: Optional[str]
+) -> MessageDefinition:
+    matches: List[MessageDefinition] = []
+    for t in types:
+        type_name = t.name or ""
+        if not name:
+            if not type_name:
+                matches.append(t)
+        elif "/" in name:
+            if type_name == name:
+                matches.append(t)
+        elif name == "Header":
+            if type_name == "std_msgs/Header":
+                matches.append(t)
+        elif type_namespace:
+            if type_name == f"{type_namespace}/{name}":
+                matches.append(t)
+        else:
+            if type_name.endswith(f"/{name}"):
+                matches.append(t)
+    if not matches:
+        raise ValueError(
+            f"Expected 1 top level type definition for '{name}' "
+            f"but found {len(matches)}"
+        )
+    if len(matches) > 1:
+        raise ValueError(
+            f"Cannot unambiguously determine fully-qualified type name for '{name}'"
+        )
+    return matches[0]
+
+
+def normalize_type(type_name: str) -> str:
+    if type_name == "char":
+        return "uint8"
+    if type_name == "byte":
+        return "int8"
+    return type_name
+
+
+def _is_builtin(type_name: str) -> bool:
+    return type_name in BUILTIN_TYPES

--- a/python_ros/tests/test_md5.py
+++ b/python_ros/tests/test_md5.py
@@ -1,0 +1,78 @@
+from python_ros.rosmsg import md5, parse
+
+MD5_TESTS = [
+    ("std_msgs/Bool", "bool data", "8b94c1b53db61fb6aed406028ad6332a"),
+    ("Int8Array", "int8[] data", "ac9c931aaf6ce145ea0383362e83c70b"),
+    ("BoolFalseConstant", "bool A=False", "d3011fbf97518e43e51a9ef7f5f352f1"),
+    (
+        "sensor_msgs/PointCloud2",
+        """# This message holds a collection of N-dimensional points, which may
+  # contain additional information such as normals, intensity, etc. The
+  # point data is stored as a binary blob, its layout described by the
+  # contents of the \"fields\" array.
+
+  # The point cloud data may be organized 2d (image-like) or 1d
+  # (unordered). Point clouds organized as 2d images may be produced by
+  # camera depth sensors such as stereo or time-of-flight.
+
+  # Time of sensor data acquisition, and the coordinate frame ID (for 3d
+  # points).
+  Header header
+
+  # 2D structure of the point cloud. If the cloud is unordered, height is
+  # 1 and width is the length of the point cloud.
+  uint32 height
+  uint32 width
+
+  # Describes the channels and their layout in the binary data blob.
+  PointField[] fields
+
+  bool    is_bigendian # Is this data bigendian?
+  uint32  point_step   # Length of a point in bytes
+  uint32  row_step     # Length of a row in bytes
+  uint8[] data         # Actual point data, size is (row_step*height)
+
+  bool is_dense        # True if there are no invalid points
+
+  =============================================================================
+  MSG: std_msgs/Header
+  # Standard metadata for higher-level stamped data types.
+  # This is generally used to communicate timestamped data
+  # in a particular coordinate frame.
+  #
+  # sequence ID: consecutively increasing ID
+  uint32 seq
+  #Two-integer timestamp that is expressed as:
+  # * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+  # * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+  # time-handling sugar is provided by the client library
+  time stamp
+  #Frame this data is associated with
+  string frame_id
+
+  =============================================================================
+  MSG: sensor_msgs/PointField
+  # This message holds the description of one point entry in the
+  # PointCloud2 message format.
+  uint8 INT8    = 1
+  uint8 UINT8   = 2
+  uint8 INT16   = 3
+  uint8 UINT16  = 4
+  uint8 INT32   = 5
+  uint8 UINT32  = 6
+  uint8 FLOAT32 = 7
+  uint8 FLOAT64 = 8
+
+  string name      # Name of field
+  uint32 offset    # Offset from start of point struct
+  uint8  datatype  # Datatype enumeration, see above
+  uint32 count     # How many elements in the field
+  """,
+        "1158d486dd51d683ce2f1be655c3c181",
+    ),
+]
+
+
+def test_md5():
+    for _name, msg_def, expected in MD5_TESTS:
+        assert md5(parse(msg_def)) == expected


### PR DESCRIPTION
## Summary
- add `pyproject.toml` and `python_ros` package scaffolding for Python ports
- implement ROS message parsing and MD5 checksum in `python_ros.rosmsg`
- test MD5 generation against sample message definitions
- configure pre-commit with Black, isort, and Flake8

## Testing
- `pre-commit run --files $(git ls-files '*.py')`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891c655d0c083308f0256cf2798eb2c