### PR TITLE
test: port rosmsg tests to python

### DIFF
--- a/python_ros/tests/conftest.py
+++ b/python_ros/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on the path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))

--- a/python_ros/tests/test_parse_ros1.py
+++ b/python_ros/tests/test_parse_ros1.py
@@ -1,0 +1,239 @@
+from python_ros.message_definition import MessageDefinition, MessageDefinitionField
+from python_ros.rosmsg.parse import fixup_types, parse
+
+
+def test_parses_single_field():
+    assert parse("string name") == [
+        MessageDefinition(
+            name=None, definitions=[MessageDefinitionField(type="string", name="name")]
+        )
+    ]
+
+
+def test_resolves_unqualified_names():
+    message_definition = (
+        "Point[] points\n" "===============\n" "MSG: geometry_msgs/Point\n" "float64 x"
+    )
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(
+                    type="geometry_msgs/Point",
+                    name="points",
+                    is_array=True,
+                    is_complex=True,
+                )
+            ],
+        ),
+        MessageDefinition(
+            name="geometry_msgs/Point",
+            definitions=[MessageDefinitionField(type="float64", name="x")],
+        ),
+    ]
+
+
+def test_normalizes_aliases():
+    assert parse("char x\nbyte y") == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="uint8", name="x"),
+                MessageDefinitionField(type="int8", name="y"),
+            ],
+        )
+    ]
+
+
+def test_ignores_comment_lines():
+    message_definition = (
+        "# your first name goes here\n"
+        "string firstName\n\n"
+        "# last name here\n"
+        "### foo bar baz?\n"
+        "string lastName\n"
+    )
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="string", name="firstName"),
+                MessageDefinitionField(type="string", name="lastName"),
+            ],
+        )
+    ]
+
+
+def test_parses_variable_length_array():
+    assert parse("string[] names") == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="string", name="names", is_array=True)
+            ],
+        )
+    ]
+
+
+def test_parses_fixed_length_array():
+    assert parse("string[3] names") == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(
+                    type="string", name="names", is_array=True, array_length=3
+                )
+            ],
+        )
+    ]
+
+
+def test_parses_nested_complex_types():
+    message_definition = (
+        "string username\n"
+        "Account account\n"
+        "===============\n"
+        "MSG: custom_type/Account\n"
+        "string name\n"
+        "uint16 id"
+    )
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="string", name="username"),
+                MessageDefinitionField(
+                    type="custom_type/Account", name="account", is_complex=True
+                ),
+            ],
+        ),
+        MessageDefinition(
+            name="custom_type/Account",
+            definitions=[
+                MessageDefinitionField(type="string", name="name"),
+                MessageDefinitionField(type="uint16", name="id"),
+            ],
+        ),
+    ]
+
+
+def test_returns_constants():
+    message_definition = (
+        "uint32 foo = 55\n"
+        "int32 bar=-11\n"
+        "float32 baz= -32.25\n"
+        "bool someBoolean = 0\n"
+        "string fooStr = Foo\n"
+        "int64 A = 0000000000000001"
+    )
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(
+                    type="uint32", name="foo", is_constant=True, value_text="55"
+                ),
+                MessageDefinitionField(
+                    type="int32", name="bar", is_constant=True, value_text="-11"
+                ),
+                MessageDefinitionField(
+                    type="float32", name="baz", is_constant=True, value_text="-32.25"
+                ),
+                MessageDefinitionField(
+                    type="bool", name="someBoolean", is_constant=True, value_text="0"
+                ),
+                MessageDefinitionField(
+                    type="string", name="fooStr", is_constant=True, value_text="Foo"
+                ),
+                MessageDefinitionField(
+                    type="int64",
+                    name="A",
+                    is_constant=True,
+                    value_text="0000000000000001",
+                ),
+            ],
+        )
+    ]
+
+
+def test_handles_python_boolean_values():
+    message_definition = "bool Alive=True\n" "bool Dead=False"
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(
+                    type="bool", name="Alive", is_constant=True, value_text="True"
+                ),
+                MessageDefinitionField(
+                    type="bool", name="Dead", is_constant=True, value_text="False"
+                ),
+            ],
+        )
+    ]
+
+
+def test_handles_type_names_for_fields():
+    assert parse("time time") == [
+        MessageDefinition(
+            name=None,
+            definitions=[MessageDefinitionField(type="time", name="time")],
+        )
+    ]
+
+    assert parse("time time_ref") == [
+        MessageDefinition(
+            name=None,
+            definitions=[MessageDefinitionField(type="time", name="time_ref")],
+        )
+    ]
+
+    message_definition = (
+        "true true\n" "===============\n" "MSG: custom/true\n" "bool false"
+    )
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="custom/true", name="true", is_complex=True)
+            ],
+        ),
+        MessageDefinition(
+            name="custom/true",
+            definitions=[MessageDefinitionField(type="bool", name="false")],
+        ),
+    ]
+
+
+def test_allows_numbers_in_package_names():
+    message_definition = (
+        "abc1/Foo2 value0\n" "==========\n" "MSG: abc1/Foo2\n" "int32 data"
+    )
+    assert parse(message_definition) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="abc1/Foo2", name="value0", is_complex=True)
+            ],
+        ),
+        MessageDefinition(
+            name="abc1/Foo2",
+            definitions=[MessageDefinitionField(type="int32", name="data")],
+        ),
+    ]
+
+
+def test_fixup_types_empty_list():
+    types: list[MessageDefinition] = []
+    fixup_types(types)
+    assert types == []
+
+
+def test_fixup_types_rewrites_names():
+    message_definition = (
+        "Point[] points\n" "===============\n" "MSG: geometry_msgs/Point\n" "float64 x"
+    )
+    types = parse(message_definition, skip_type_fixup=True)
+    assert types[0].definitions[0].type == "Point"
+    fixup_types(types)
+    assert types[0].definitions[0].type == "geometry_msgs/Point"

--- a/python_ros/tests/test_parse_ros2.py
+++ b/python_ros/tests/test_parse_ros2.py
@@ -1,0 +1,8 @@
+import pytest
+
+from python_ros.rosmsg.parse import parse
+
+
+def test_parse_ros2_not_implemented():
+    with pytest.raises(NotImplementedError):
+        parse("string name", ros2=True)


### PR DESCRIPTION
## Summary
- port rosmsg parser tests from TypeScript to Python
- ensure project root is on PYTHONPATH for tests
- confirm ros2 parser raises NotImplementedError

## Testing
- `pre-commit run --files python_ros/tests/conftest.py python_ros/tests/test_parse_ros1.py python_ros/tests/test_parse_ros2.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891e4b6751c8330ba2ecddc54a857cf