### PR TITLE
feat: add rostime python port

### DIFF
--- a/python_ros/rostime/__init__.py
+++ b/python_ros/rostime/__init__.py
@@ -1,0 +1,250 @@
+"""ROS Time and Duration utilities."""
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+
+@dataclass
+class Time:
+    """Represents a ROS time with second and nanosecond fields."""
+
+    sec: int
+    nsec: int
+
+
+Duration = Time
+
+
+def is_time(obj: object | None) -> bool:
+    """Return ``True`` if *obj* looks like a :class:`Time`."""
+
+    if isinstance(obj, Time):
+        return True
+    if isinstance(obj, dict):
+        return set(obj.keys()) == {"sec", "nsec"}
+    return False
+
+
+def to_string(stamp: Time, allow_negative: bool = False) -> str:
+    if not allow_negative and (stamp.sec < 0 or stamp.nsec < 0):
+        raise ValueError(
+            f"Invalid negative time {{ sec: {stamp.sec}, nsec: {stamp.nsec} }}"
+        )
+    return f"{int(stamp.sec)}.{int(stamp.nsec):09d}"
+
+
+def _parse_nanoseconds(digits: str) -> int:
+    digits_short = 9 - len(digits)
+    return round(int(digits, 10) * 10**digits_short)
+
+
+def from_string(text: str) -> Optional[Time]:
+    if re.fullmatch(r"\d+\.?", text):
+        sec = int(text.rstrip("."))
+        return Time(sec=sec, nsec=0)
+    if not re.fullmatch(r"\d+\.\d+", text):
+        return None
+    whole, frac = text.split(".", 1)
+    sec = int(whole)
+    nsec = _parse_nanoseconds(frac)
+    return fix_time(Time(sec=sec, nsec=nsec))
+
+
+def to_rfc3339_string(stamp: Time) -> str:
+    if stamp.sec < 0 or stamp.nsec < 0:
+        raise ValueError(
+            f"Invalid negative time {{ sec: {stamp.sec}, nsec: {stamp.nsec} }}"
+        )
+    if stamp.nsec >= 1_000_000_000:
+        raise ValueError(f"Invalid nanosecond value {stamp.nsec}")
+    date = datetime.fromtimestamp(stamp.sec, tz=timezone.utc)
+    return date.strftime("%Y-%m-%dT%H:%M:%S") + f".{stamp.nsec:09d}Z"
+
+
+_RFC3339_RE = re.compile(
+    r"^(\d{4,})-(\d\d)-(\d\d)[Tt](\d\d):(\d\d):(\d\d)"
+    r"(?:\.(\d+))?(?:[Zz]|([+-])(\d\d):(\d\d))$"
+)
+
+
+def from_rfc3339_string(text: str) -> Optional[Time]:
+    m = _RFC3339_RE.fullmatch(text)
+    if not m:
+        return None
+    year, month, day, hour, minute, second, frac, sign, off_h, off_m = m.groups()
+    dt = datetime(
+        int(year),
+        int(month),
+        int(day),
+        int(hour),
+        int(minute),
+        int(second),
+        tzinfo=timezone.utc,
+    )
+    if sign:
+        offset = timedelta(hours=int(off_h), minutes=int(off_m))
+        if sign == "+":
+            dt -= offset
+        else:
+            dt += offset
+    sec = int(dt.timestamp())
+    nsec = _parse_nanoseconds(frac) if frac else 0
+    return fix_time(Time(sec=sec, nsec=nsec))
+
+
+def to_date(stamp: Time) -> datetime:
+    return datetime.fromtimestamp(stamp.sec + stamp.nsec / 1e9, tz=timezone.utc)
+
+
+def from_date(date: datetime) -> Time:
+    millis = int(date.timestamp() * 1000)
+    sec = millis // 1000
+    nsec = (millis % 1000) * 1_000_000
+    return Time(sec=sec, nsec=nsec)
+
+
+def percent_of(start: Time, end: Time, target: Time) -> float:
+    total = subtract(end, start)
+    part = subtract(target, start)
+    return to_sec(part) / to_sec(total)
+
+
+def interpolate(start: Time, end: Time, fraction: float) -> Time:
+    duration = subtract(end, start)
+    return add(start, from_sec(fraction * to_sec(duration)))
+
+
+def fix_time(t: Time, allow_negative: bool = False) -> Time:
+    secs_from_nanos = t.nsec // 1_000_000_000
+    new_sec = t.sec + secs_from_nanos
+    new_nsec = t.nsec % 1_000_000_000
+    if new_nsec < 0:
+        new_nsec += 1_000_000_000
+        new_sec -= 1
+    result = Time(sec=new_sec, nsec=new_nsec)
+    if (not allow_negative and result.sec < 0) or result.nsec < 0:
+        raise ValueError(f"Cannot normalize invalid time {to_string(result, True)}")
+    return result
+
+
+def add(a: Time, b: Time) -> Time:
+    return fix_time(Time(sec=a.sec + b.sec, nsec=a.nsec + b.nsec))
+
+
+def subtract(a: Time, b: Time) -> Time:
+    return fix_time(Time(sec=a.sec - b.sec, nsec=a.nsec - b.nsec), allow_negative=True)
+
+
+def to_nanosec(t: Time) -> int:
+    return t.sec * 1_000_000_000 + t.nsec
+
+
+def to_microsec(t: Time) -> float:
+    return (t.sec * 1_000_000_000 + t.nsec) / 1000
+
+
+def to_sec(t: Time) -> float:
+    return t.sec + t.nsec * 1e-9
+
+
+def from_sec(value: float) -> Time:
+    sec = math.trunc(value)
+    nsec = round((value - sec) * 1_000_000_000)
+    sec += math.trunc(nsec / 1_000_000_000)
+    nsec %= 1_000_000_000
+    return Time(sec=sec, nsec=nsec)
+
+
+def from_nanosec(nsec: int) -> Time:
+    return Time(sec=nsec // 1_000_000_000, nsec=nsec % 1_000_000_000)
+
+
+def to_millis(t: Time, round_up: bool = True) -> int:
+    seconds_millis = t.sec * 1000
+    nsec_millis = t.nsec / 1_000_000
+    if round_up:
+        return seconds_millis + math.ceil(nsec_millis)
+    return seconds_millis + math.floor(nsec_millis)
+
+
+def from_millis(value: int | float) -> Time:
+    sec = math.trunc(value / 1000)
+    nsec = round((value - sec * 1000) * 1_000_000)
+    sec += math.trunc(nsec / 1_000_000_000)
+    nsec %= 1_000_000_000
+    return Time(sec=sec, nsec=nsec)
+
+
+def from_micros(value: int | float) -> Time:
+    sec = math.trunc(value / 1_000_000)
+    nsec = round((value - sec * 1_000_000) * 1000)
+    sec += math.trunc(nsec / 1_000_000_000)
+    nsec %= 1_000_000_000
+    return Time(sec=sec, nsec=nsec)
+
+
+def clamp_time(time: Time, start: Time, end: Time) -> Time:
+    if compare(start, time) > 0:
+        return Time(sec=start.sec, nsec=start.nsec)
+    if compare(end, time) < 0:
+        return Time(sec=end.sec, nsec=end.nsec)
+    return Time(sec=time.sec, nsec=time.nsec)
+
+
+def is_time_in_range_inclusive(time: Time, start: Time, end: Time) -> bool:
+    if compare(start, time) > 0 or compare(end, time) < 0:
+        return False
+    return True
+
+
+def compare(left: Time, right: Time) -> int:
+    sec_diff = left.sec - right.sec
+    return sec_diff if sec_diff != 0 else left.nsec - right.nsec
+
+
+def is_less_than(left: Time, right: Time) -> bool:
+    return compare(left, right) < 0
+
+
+def is_greater_than(left: Time, right: Time) -> bool:
+    return compare(left, right) > 0
+
+
+def are_equal(left: Time, right: Time) -> bool:
+    return left.sec == right.sec and left.nsec == right.nsec
+
+
+__all__ = [
+    "Time",
+    "Duration",
+    "is_time",
+    "to_string",
+    "from_string",
+    "to_rfc3339_string",
+    "from_rfc3339_string",
+    "to_date",
+    "from_date",
+    "percent_of",
+    "interpolate",
+    "fix_time",
+    "add",
+    "subtract",
+    "to_nanosec",
+    "to_microsec",
+    "to_sec",
+    "from_sec",
+    "from_nanosec",
+    "to_millis",
+    "from_millis",
+    "from_micros",
+    "clamp_time",
+    "is_time_in_range_inclusive",
+    "compare",
+    "is_less_than",
+    "is_greater_than",
+    "are_equal",
+]

--- a/python_ros/tests/test_rostime.py
+++ b/python_ros/tests/test_rostime.py
@@ -1,0 +1,67 @@
+import datetime
+
+import python_ros.rostime as rostime
+
+
+def test_is_time():
+    assert not rostime.is_time(None)
+    assert not rostime.is_time(True)
+    assert not rostime.is_time({"sec": 1})
+    assert not rostime.is_time({"nsec": 1})
+    assert not rostime.is_time({"sec": 1, "nsec": 1, "other": 0})
+    assert rostime.is_time({"sec": 0, "nsec": 0})
+    assert rostime.is_time(rostime.Time(1, 0))
+
+
+def test_rfc3339_roundtrip():
+    t = rostime.Time(sec=1632939128, nsec=123456789)
+    text = rostime.to_rfc3339_string(t)
+    assert text == "2021-09-29T18:12:08.123456789Z"
+    assert rostime.from_rfc3339_string(text) == t
+
+
+def test_to_from_string():
+    t = rostime.Time(10, 5)
+    s = rostime.to_string(t)
+    assert s == "10.000000005"
+    assert rostime.from_string(s) == t
+
+
+def test_conversions():
+    t = rostime.Time(1, 500000000)
+    assert rostime.to_sec(t) == 1.5
+    assert rostime.from_sec(1.5) == t
+    assert rostime.to_nanosec(t) == 1_500_000_000
+    assert rostime.from_nanosec(1_500_000_000) == t
+    assert rostime.to_millis(t) == 1500
+    assert rostime.from_millis(1500) == t
+    assert rostime.from_micros(1_500_000) == t
+
+
+def test_clamp_and_compare():
+    start = rostime.Time(0, 100)
+    end = rostime.Time(100, 100)
+    before = rostime.Time(0, 99)
+    after = rostime.Time(100, 101)
+    assert rostime.clamp_time(before, start, end) == start
+    assert rostime.clamp_time(after, start, end) == end
+    assert rostime.is_time_in_range_inclusive(start, start, end)
+    assert not rostime.is_time_in_range_inclusive(before, start, end)
+    assert rostime.compare(start, end) < 0
+    assert rostime.is_less_than(start, end)
+    assert rostime.is_greater_than(end, start)
+    assert rostime.are_equal(start, rostime.Time(0, 100))
+
+
+def test_percent_of_and_interpolate():
+    start = rostime.Time(0, 0)
+    end = rostime.Time(10, 0)
+    middle = rostime.Time(5, 0)
+    assert rostime.percent_of(start, end, middle) == 0.5
+    assert rostime.interpolate(start, end, 0.5) == middle
+
+
+def test_date_roundtrip():
+    dt = datetime.datetime(2021, 9, 29, 18, 12, 8, 123000, tzinfo=datetime.timezone.utc)
+    t = rostime.from_date(dt)
+    assert rostime.to_date(t) == dt


### PR DESCRIPTION
## Summary
- port rostime utilities to Python
- add tests for RFC3339 conversions and time helpers

## Testing
- `python -m pre_commit run --files python_ros/rostime/__init__.py python_ros/tests/test_rostime.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891f3cbcd68833088e62f52375c12e0