### PR TITLE
feat: add ros2 parser for python rosmsg

### DIFF
--- a/python_ros/message_definition/__init__.py
+++ b/python_ros/message_definition/__init__.py
@@ -10,7 +10,10 @@ class MessageDefinitionField:
     name: str
     is_array: bool = False
     array_length: Optional[int] = None
+    array_upper_bound: Optional[int] = None
+    upper_bound: Optional[int] = None
     is_constant: bool = False
+    default_value: Any = None
     value: Any = None
     value_text: Optional[str] = None
     is_complex: bool = False

--- a/python_ros/rosmsg/parse.py
+++ b/python_ros/rosmsg/parse.py
@@ -55,7 +55,9 @@ ROS2_BUILTIN_TYPES = {
 
 TYPE = r"(?P<type>[a-zA-Z0-9_/]+)"
 STRING_BOUND = r"(?:<=(?P<stringBound>\d+))"
-ARRAY_BOUND = r"(?:(?P<unboundedArray>\[\])|\[(?P<arrayLength>\d+)\]|\[<=(?P<arrayBound>\d+)\])"
+ARRAY_BOUND = (
+    r"(?:(?P<unboundedArray>\[\])|\[(?P<arrayLength>\d+)\]|\[<=(?P<arrayBound>\d+)\])"
+)
 NAME = r"(?P<name>[a-zA-Z0-9_]+)"
 QUOTED_STRING = r"'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\""
 COMMENT_TERMINATED_LITERAL = (
@@ -69,7 +71,11 @@ DEFAULT_VALUE_ARRAY = (
     r"\[(?:" + ARRAY_TERMINATED_LITERAL + r",)*" + ARRAY_TERMINATED_LITERAL + r"?\]"
 )
 DEFAULT_VALUE = (
-    r"(?P<defaultValue>" + DEFAULT_VALUE_ARRAY + r"|" + COMMENT_TERMINATED_LITERAL + r")"
+    r"(?P<defaultValue>"
+    + DEFAULT_VALUE_ARRAY
+    + r"|"
+    + COMMENT_TERMINATED_LITERAL
+    + r")"
 )
 COMMENT = r"(?:#.*)"
 DEFINITION_LINE_REGEX = re.compile(
@@ -122,7 +128,9 @@ def _parse_string_literal(maybe_quoted: str) -> str:
     for q in ("'", '"'):
         if s.startswith(q):
             if not s.endswith(q):
-                raise ValueError(f"Expected terminating {q} in string literal: {maybe_quoted}")
+                raise ValueError(
+                    f"Expected terminating {q} in string literal: {maybe_quoted}"
+                )
             quote = q
             s = s[len(q) : -len(q)]
             break
@@ -269,15 +277,16 @@ def _build_ros2_type(lines: List[str]) -> MessageDefinition:
             array_upper_bound=int(array_bound) if array_bound else None,
             upper_bound=int(string_bound) if string_bound else None,
             is_constant=constant_value is not None,
-            default_value=
-                _parse_array_literal(type_name, default_value.strip())
-                if default_value is not None and is_array
-                else (_parse_primitive_literal(type_name, default_value.strip())
-                      if default_value is not None else None),
-            value=
-                _parse_primitive_literal(type_name, constant_value.strip())
-                if constant_value is not None
-                else None,
+            default_value=_parse_array_literal(type_name, default_value.strip())
+            if default_value is not None and is_array
+            else (
+                _parse_primitive_literal(type_name, default_value.strip())
+                if default_value is not None
+                else None
+            ),
+            value=_parse_primitive_literal(type_name, constant_value.strip())
+            if constant_value is not None
+            else None,
             value_text=constant_value.strip() if constant_value is not None else None,
         )
         definitions.append(field)
@@ -294,11 +303,17 @@ def parse(
         if line.startswith("#"):
             continue
         if line.startswith("=="):
-            types.append(_build_ros2_type(definition_lines) if ros2 else _build_type(definition_lines))
+            types.append(
+                _build_ros2_type(definition_lines)
+                if ros2
+                else _build_type(definition_lines)
+            )
             definition_lines = []
         else:
             definition_lines.append(line)
-    types.append(_build_ros2_type(definition_lines) if ros2 else _build_type(definition_lines))
+    types.append(
+        _build_ros2_type(definition_lines) if ros2 else _build_type(definition_lines)
+    )
 
     unique: List[MessageDefinition] = []
     for t in types:

--- a/python_ros/rosmsg/parse.py
+++ b/python_ros/rosmsg/parse.py
@@ -29,12 +29,264 @@ BUILTIN_TYPES = {
 }
 
 
+ROS2_BUILTIN_TYPES = {
+    "bool",
+    "byte",
+    "char",
+    "float32",
+    "float64",
+    "int8",
+    "uint8",
+    "int16",
+    "uint16",
+    "int32",
+    "uint32",
+    "int64",
+    "uint64",
+    "string",
+    "wstring",
+    "time",
+    "duration",
+    "builtin_interfaces/Time",
+    "builtin_interfaces/Duration",
+    "builtin_interfaces/msg/Time",
+    "builtin_interfaces/msg/Duration",
+}
+
+TYPE = r"(?P<type>[a-zA-Z0-9_/]+)"
+STRING_BOUND = r"(?:<=(?P<stringBound>\d+))"
+ARRAY_BOUND = r"(?:(?P<unboundedArray>\[\])|\[(?P<arrayLength>\d+)\]|\[<=(?P<arrayBound>\d+)\])"
+NAME = r"(?P<name>[a-zA-Z0-9_]+)"
+QUOTED_STRING = r"'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\""
+COMMENT_TERMINATED_LITERAL = (
+    r"(?:" + QUOTED_STRING + r"|(?:\\.|[^\s'\"#\\])(?:\\.|[^#\\])*)"
+)
+ARRAY_TERMINATED_LITERAL = (
+    r"(?:" + QUOTED_STRING + r"|(?:\\.|[^\s'\"\],#\\])(?:\\.|[^\],#\\])*)"
+)
+CONSTANT_ASSIGNMENT = r"\s*=\s*(?P<constantValue>" + COMMENT_TERMINATED_LITERAL + r"?)"
+DEFAULT_VALUE_ARRAY = (
+    r"\[(?:" + ARRAY_TERMINATED_LITERAL + r",)*" + ARRAY_TERMINATED_LITERAL + r"?\]"
+)
+DEFAULT_VALUE = (
+    r"(?P<defaultValue>" + DEFAULT_VALUE_ARRAY + r"|" + COMMENT_TERMINATED_LITERAL + r")"
+)
+COMMENT = r"(?:#.*)"
+DEFINITION_LINE_REGEX = re.compile(
+    r"^"
+    + TYPE
+    + STRING_BOUND
+    + r"?"
+    + ARRAY_BOUND
+    + r"?\s+"
+    + NAME
+    + r"(?:"
+    + CONSTANT_ASSIGNMENT
+    + r"|\s+"
+    + DEFAULT_VALUE
+    + r")?\s*"
+    + COMMENT
+    + r"?$"
+)
+
+STRING_ESCAPES = (
+    r"\\(?P<char>['\"abfnrtv\\])|\\(?P<oct>[0-7]{1,3})|"
+    r"\\x(?P<hex2>[a-fA-F0-9]{2})|\\u(?P<hex4>[a-fA-F0-9]{4})|"
+    r"\\U(?P<hex8>[a-fA-F0-9]{8})"
+)
+
+LITERAL_REGEX = re.compile(ARRAY_TERMINATED_LITERAL)
+COMMA_OR_END_REGEX = re.compile(r"\s*(,)?\s*|\s*$")
+
+
+def _parse_big_int_literal(text: str, min_value: int, max_value: int) -> int:
+    value = int(text)
+    if value < min_value or value > max_value:
+        raise ValueError(f"Number {text} out of range [{min_value}, {max_value}]")
+    return value
+
+
+def _parse_number_literal(text: str, min_value: int, max_value: int) -> int:
+    try:
+        value = int(text)
+    except ValueError:
+        raise ValueError(f"Invalid numeric literal: {text}")
+    if value < min_value or value > max_value:
+        raise ValueError(f"Number {text} out of range [{min_value}, {max_value}]")
+    return value
+
+
+def _parse_string_literal(maybe_quoted: str) -> str:
+    quote = ""
+    s = maybe_quoted
+    for q in ("'", '"'):
+        if s.startswith(q):
+            if not s.endswith(q):
+                raise ValueError(f"Expected terminating {q} in string literal: {maybe_quoted}")
+            quote = q
+            s = s[len(q) : -len(q)]
+            break
+    pattern = rf"^(?:[^\\{quote}]|{STRING_ESCAPES})*$"
+    if re.fullmatch(pattern, s) is None:
+        raise ValueError(f"Invalid string literal: {s}")
+
+    def replace(match: re.Match) -> str:
+        groups = match.groupdict()
+        if groups.get("char"):
+            return {
+                "'": "'",
+                '"': '"',
+                "a": "\x07",
+                "b": "\b",
+                "f": "\f",
+                "n": "\n",
+                "r": "\r",
+                "t": "\t",
+                "v": "\v",
+                "\\": "\\",
+            }[groups["char"]]
+        if groups.get("oct"):
+            return chr(int(groups["oct"], 8))
+        hex_val = groups.get("hex2") or groups.get("hex4") or groups.get("hex8")
+        if hex_val:
+            return chr(int(hex_val, 16))
+        raise ValueError("Expected exactly one matched group")
+
+    return re.sub(STRING_ESCAPES, replace, s)
+
+
+def _parse_primitive_literal(type_name: str, text: str):
+    if type_name == "bool":
+        if text in {"true", "True", "1"}:
+            return True
+        if text in {"false", "False", "0"}:
+            return False
+    elif type_name in {"float32", "float64"}:
+        value = float(text)
+        if value == value:  # not NaN
+            return value
+    elif type_name == "int8":
+        return _parse_number_literal(text, -0x80, 0x7F)
+    elif type_name == "uint8":
+        return _parse_number_literal(text, 0, 0xFF)
+    elif type_name == "int16":
+        return _parse_number_literal(text, -0x8000, 0x7FFF)
+    elif type_name == "uint16":
+        return _parse_number_literal(text, 0, 0xFFFF)
+    elif type_name == "int32":
+        return _parse_number_literal(text, -0x80000000, 0x7FFFFFFF)
+    elif type_name == "uint32":
+        return _parse_number_literal(text, 0, 0xFFFFFFFF)
+    elif type_name == "int64":
+        return _parse_big_int_literal(text, -0x8000000000000000, 0x7FFFFFFFFFFFFFFF)
+    elif type_name == "uint64":
+        return _parse_big_int_literal(text, 0, 0xFFFFFFFFFFFFFFFF)
+    elif type_name in {"string", "wstring"}:
+        return _parse_string_literal(text)
+    raise ValueError(f"Invalid literal of type {type_name}: {text}")
+
+
+def _parse_array_literal(type_name: str, raw: str):
+    if not raw.startswith("[") or not raw.endswith("]"):
+        raise ValueError("Array must start with [ and end with ]")
+    inner = raw[1:-1]
+    if type_name in {"string", "wstring"}:
+        results = []
+        offset = 0
+        while offset < len(inner):
+            if inner[offset] == ",":
+                raise ValueError("Expected array element before comma")
+            m = LITERAL_REGEX.match(inner, offset)
+            if m:
+                results.append(_parse_string_literal(m.group(0)))
+                offset = m.end()
+            m = COMMA_OR_END_REGEX.match(inner, offset)
+            if not m:
+                raise ValueError("Expected comma or end of array")
+            if not m.group(1):
+                break
+            offset = m.end()
+        return results
+    return [
+        _parse_primitive_literal(type_name, part.strip())
+        for part in inner.split(",")
+        if part.strip() != ""
+    ]
+
+
+def _normalize_type_ros2(type_name: str) -> str:
+    if type_name in {"char", "byte"}:
+        return "uint8"
+    if type_name in {"builtin_interfaces/Time", "builtin_interfaces/msg/Time"}:
+        return "time"
+    if type_name in {"builtin_interfaces/Duration", "builtin_interfaces/msg/Duration"}:
+        return "duration"
+    return type_name
+
+
+def _build_ros2_type(lines: List[str]) -> MessageDefinition:
+    definitions: List[MessageDefinitionField] = []
+    complex_type_name: Optional[str] = None
+    for line in lines:
+        if line.startswith("#"):
+            continue
+        m_msg = re.match(r"^MSG: ([^ ]+)\s*(?:#.+)?$", line)
+        if m_msg:
+            complex_type_name = m_msg.group(1)
+            continue
+        m = DEFINITION_LINE_REGEX.match(line)
+        if not m:
+            raise ValueError(f"Could not parse line: '{line}'")
+        groups = m.groupdict()
+        raw_type = groups["type"]
+        type_name = _normalize_type_ros2(raw_type)
+        string_bound = groups.get("stringBound")
+        unbounded_array = groups.get("unboundedArray")
+        array_length = groups.get("arrayLength")
+        array_bound = groups.get("arrayBound")
+        name = groups["name"]
+        constant_value = groups.get("constantValue")
+        default_value = groups.get("defaultValue")
+
+        if string_bound is not None and type_name not in {"string", "wstring"}:
+            raise ValueError(f"Invalid string bound for type {type_name}")
+        if constant_value is not None:
+            if re.fullmatch(r"[A-Z](?:_?[A-Z0-9]+)*", name) is None:
+                raise ValueError(f"Invalid constant name: {name}")
+        else:
+            if re.fullmatch(r"[a-z](?:_?[a-z0-9]+)*", name) is None:
+                raise ValueError(f"Invalid field name: {name}")
+
+        is_complex = type_name not in ROS2_BUILTIN_TYPES
+        is_array = bool(unbounded_array or array_length or array_bound)
+
+        field = MessageDefinitionField(
+            name=name,
+            type=type_name,
+            is_complex=is_complex,
+            is_array=is_array,
+            array_length=int(array_length) if array_length else None,
+            array_upper_bound=int(array_bound) if array_bound else None,
+            upper_bound=int(string_bound) if string_bound else None,
+            is_constant=constant_value is not None,
+            default_value=
+                _parse_array_literal(type_name, default_value.strip())
+                if default_value is not None and is_array
+                else (_parse_primitive_literal(type_name, default_value.strip())
+                      if default_value is not None else None),
+            value=
+                _parse_primitive_literal(type_name, constant_value.strip())
+                if constant_value is not None
+                else None,
+            value_text=constant_value.strip() if constant_value is not None else None,
+        )
+        definitions.append(field)
+    return MessageDefinition(name=complex_type_name, definitions=definitions)
+
+
 def parse(
     message_definition: str, ros2: bool = False, skip_type_fixup: bool = False
 ) -> List[MessageDefinition]:
-    if ros2:
-        raise NotImplementedError("ROS2 parsing not yet implemented")
-
     lines = [line.strip() for line in message_definition.splitlines() if line.strip()]
     definition_lines: List[str] = []
     types: List[MessageDefinition] = []
@@ -42,11 +294,11 @@ def parse(
         if line.startswith("#"):
             continue
         if line.startswith("=="):
-            types.append(_build_type(definition_lines))
+            types.append(_build_ros2_type(definition_lines) if ros2 else _build_type(definition_lines))
             definition_lines = []
         else:
             definition_lines.append(line)
-    types.append(_build_type(definition_lines))
+    types.append(_build_ros2_type(definition_lines) if ros2 else _build_type(definition_lines))
 
     unique: List[MessageDefinition] = []
     for t in types:

--- a/python_ros/tests/test_parse_ros2.py
+++ b/python_ros/tests/test_parse_ros2.py
@@ -1,8 +1,176 @@
 import pytest
 
+from python_ros.message_definition import MessageDefinition, MessageDefinitionField
 from python_ros.rosmsg.parse import parse
 
 
-def test_parse_ros2_not_implemented():
-    with pytest.raises(NotImplementedError):
-        parse("string name", ros2=True)
+def test_parses_single_field():
+    assert parse("string name", ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[MessageDefinitionField(type="string", name="name")],
+        )
+    ]
+
+
+def test_resolves_unqualified_names():
+    message_definition = (
+        "Point[] points\n" "===============\n" "MSG: geometry_msgs/Point\n" "float64 x"
+    )
+    assert parse(message_definition, ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(
+                    type="geometry_msgs/Point", name="points", is_array=True, is_complex=True
+                )
+            ],
+        ),
+        MessageDefinition(
+            name="geometry_msgs/Point",
+            definitions=[MessageDefinitionField(type="float64", name="x")],
+        ),
+    ]
+
+
+def test_normalizes_aliases():
+    assert parse("char x\nbyte y", ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="uint8", name="x"),
+                MessageDefinitionField(type="uint8", name="y"),
+            ],
+        )
+    ]
+
+
+def test_ignores_comment_lines():
+    message_definition = (
+        "# your first name goes here\n"
+        "string first_name\n\n"
+        "# last name here\n"
+        "### foo bar baz?\n"
+        "string last_name\n"
+    )
+    assert parse(message_definition, ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="string", name="first_name"),
+                MessageDefinitionField(type="string", name="last_name"),
+            ],
+        )
+    ]
+
+
+def test_parses_variable_length_array():
+    assert parse("string[] names", ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[MessageDefinitionField(type="string", name="names", is_array=True)],
+        )
+    ]
+
+
+def test_parses_fixed_length_array():
+    assert parse("string[3] names", ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="string", name="names", is_array=True, array_length=3)
+            ],
+        )
+    ]
+
+
+def test_parses_nested_complex_types():
+    message_definition = (
+        "string username\n"
+        "Account account\n"
+        "===============\n"
+        "MSG: custom_type/Account\n"
+        "string name\n"
+        "uint16 id"
+    )
+    assert parse(message_definition, ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="string", name="username"),
+                MessageDefinitionField(
+                    type="custom_type/Account", name="account", is_complex=True
+                ),
+            ],
+        ),
+        MessageDefinition(
+            name="custom_type/Account",
+            definitions=[
+                MessageDefinitionField(type="string", name="name"),
+                MessageDefinitionField(type="uint16", name="id"),
+            ],
+        ),
+    ]
+
+
+def test_returns_constants():
+    message_definition = (
+        "uint32 FOO = 55\n"
+        "int32 BAR=-11\n"
+        "float32 BAZ= -32.25\n"
+        "bool SOME_BOOLEAN = 0\n"
+        "string FOO_STR = Foo\n"
+        "int64 A = 0000000000000001"
+    )
+    assert parse(message_definition, ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="uint32", name="FOO", is_constant=True, value=55, value_text="55"),
+                MessageDefinitionField(type="int32", name="BAR", is_constant=True, value=-11, value_text="-11"),
+                MessageDefinitionField(type="float32", name="BAZ", is_constant=True, value=-32.25, value_text="-32.25"),
+                MessageDefinitionField(type="bool", name="SOME_BOOLEAN", is_constant=True, value=False, value_text="0"),
+                MessageDefinitionField(type="string", name="FOO_STR", is_constant=True, value="Foo", value_text="Foo"),
+                MessageDefinitionField(type="int64", name="A", is_constant=True, value=1, value_text="0000000000000001"),
+            ],
+        )
+    ]
+
+
+def test_handles_python_boolean_values():
+    message_definition = "bool ALIVE=True\n" "bool DEAD=False"
+    assert parse(message_definition, ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="bool", name="ALIVE", is_constant=True, value=True, value_text="True"),
+                MessageDefinitionField(type="bool", name="DEAD", is_constant=True, value=False, value_text="False"),
+            ],
+        )
+    ]
+
+
+def test_handles_type_names_for_fields():
+    assert parse("time time", ros2=True) == [
+        MessageDefinition(name=None, definitions=[MessageDefinitionField(type="time", name="time")])
+    ]
+
+    assert parse("time time_ref", ros2=True) == [
+        MessageDefinition(name=None, definitions=[MessageDefinitionField(type="time", name="time_ref")])
+    ]
+
+    message_definition = (
+        "true true\n" "===============\n" "MSG: custom/true\n" "bool false"
+    )
+    assert parse(message_definition, ros2=True) == [
+        MessageDefinition(
+            name=None,
+            definitions=[
+                MessageDefinitionField(type="custom/true", name="true", is_complex=True)
+            ],
+        ),
+        MessageDefinition(
+            name="custom/true",
+            definitions=[MessageDefinitionField(type="bool", name="false")],
+        ),
+    ]

--- a/python_ros/tests/test_parse_ros2.py
+++ b/python_ros/tests/test_parse_ros2.py
@@ -1,5 +1,3 @@
-import pytest
-
 from python_ros.message_definition import MessageDefinition, MessageDefinitionField
 from python_ros.rosmsg.parse import parse
 
@@ -22,7 +20,10 @@ def test_resolves_unqualified_names():
             name=None,
             definitions=[
                 MessageDefinitionField(
-                    type="geometry_msgs/Point", name="points", is_array=True, is_complex=True
+                    type="geometry_msgs/Point",
+                    name="points",
+                    is_array=True,
+                    is_complex=True,
                 )
             ],
         ),
@@ -68,7 +69,9 @@ def test_parses_variable_length_array():
     assert parse("string[] names", ros2=True) == [
         MessageDefinition(
             name=None,
-            definitions=[MessageDefinitionField(type="string", name="names", is_array=True)],
+            definitions=[
+                MessageDefinitionField(type="string", name="names", is_array=True)
+            ],
         )
     ]
 
@@ -78,7 +81,9 @@ def test_parses_fixed_length_array():
         MessageDefinition(
             name=None,
             definitions=[
-                MessageDefinitionField(type="string", name="names", is_array=True, array_length=3)
+                MessageDefinitionField(
+                    type="string", name="names", is_array=True, array_length=3
+                )
             ],
         )
     ]
@@ -126,12 +131,48 @@ def test_returns_constants():
         MessageDefinition(
             name=None,
             definitions=[
-                MessageDefinitionField(type="uint32", name="FOO", is_constant=True, value=55, value_text="55"),
-                MessageDefinitionField(type="int32", name="BAR", is_constant=True, value=-11, value_text="-11"),
-                MessageDefinitionField(type="float32", name="BAZ", is_constant=True, value=-32.25, value_text="-32.25"),
-                MessageDefinitionField(type="bool", name="SOME_BOOLEAN", is_constant=True, value=False, value_text="0"),
-                MessageDefinitionField(type="string", name="FOO_STR", is_constant=True, value="Foo", value_text="Foo"),
-                MessageDefinitionField(type="int64", name="A", is_constant=True, value=1, value_text="0000000000000001"),
+                MessageDefinitionField(
+                    type="uint32",
+                    name="FOO",
+                    is_constant=True,
+                    value=55,
+                    value_text="55",
+                ),
+                MessageDefinitionField(
+                    type="int32",
+                    name="BAR",
+                    is_constant=True,
+                    value=-11,
+                    value_text="-11",
+                ),
+                MessageDefinitionField(
+                    type="float32",
+                    name="BAZ",
+                    is_constant=True,
+                    value=-32.25,
+                    value_text="-32.25",
+                ),
+                MessageDefinitionField(
+                    type="bool",
+                    name="SOME_BOOLEAN",
+                    is_constant=True,
+                    value=False,
+                    value_text="0",
+                ),
+                MessageDefinitionField(
+                    type="string",
+                    name="FOO_STR",
+                    is_constant=True,
+                    value="Foo",
+                    value_text="Foo",
+                ),
+                MessageDefinitionField(
+                    type="int64",
+                    name="A",
+                    is_constant=True,
+                    value=1,
+                    value_text="0000000000000001",
+                ),
             ],
         )
     ]
@@ -143,8 +184,20 @@ def test_handles_python_boolean_values():
         MessageDefinition(
             name=None,
             definitions=[
-                MessageDefinitionField(type="bool", name="ALIVE", is_constant=True, value=True, value_text="True"),
-                MessageDefinitionField(type="bool", name="DEAD", is_constant=True, value=False, value_text="False"),
+                MessageDefinitionField(
+                    type="bool",
+                    name="ALIVE",
+                    is_constant=True,
+                    value=True,
+                    value_text="True",
+                ),
+                MessageDefinitionField(
+                    type="bool",
+                    name="DEAD",
+                    is_constant=True,
+                    value=False,
+                    value_text="False",
+                ),
             ],
         )
     ]
@@ -152,11 +205,16 @@ def test_handles_python_boolean_values():
 
 def test_handles_type_names_for_fields():
     assert parse("time time", ros2=True) == [
-        MessageDefinition(name=None, definitions=[MessageDefinitionField(type="time", name="time")])
+        MessageDefinition(
+            name=None, definitions=[MessageDefinitionField(type="time", name="time")]
+        )
     ]
 
     assert parse("time time_ref", ros2=True) == [
-        MessageDefinition(name=None, definitions=[MessageDefinitionField(type="time", name="time_ref")])
+        MessageDefinition(
+            name=None,
+            definitions=[MessageDefinitionField(type="time", name="time_ref")],
+        )
     ]
 
     message_definition = (


### PR DESCRIPTION
## Summary
- add ROS2 message definition parser to python rosmsg
- extend message definition fields to store bounds and default values
- cover ROS2 parsing with unit tests

## Testing
- `pytest python_ros/tests/test_parse_ros1.py python_ros/tests/test_parse_ros2.py`
- `npm test packages/rosmsg/src/parse.ros2.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6891f363c1b48330b7851e2eff3a9f30