### PR TITLE
feat: add ROS message stringify utility and tests

### DIFF
--- a/python_ros/rosmsg/__init__.py
+++ b/python_ros/rosmsg/__init__.py
@@ -1,4 +1,5 @@
 from .md5 import md5
 from .parse import fixup_types, normalize_type, parse
+from .stringify import stringify
 
-__all__ = ["parse", "fixup_types", "normalize_type", "md5"]
+__all__ = ["parse", "stringify", "fixup_types", "normalize_type", "md5"]

--- a/python_ros/rosmsg/stringify.py
+++ b/python_ros/rosmsg/stringify.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+from ..message_definition import MessageDefinition
+
+
+def _stringify_value(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, float):
+        return format(value, "g")
+    return str(value)
+
+
+def stringify_default_value(value: Any) -> str:
+    if isinstance(value, list):
+        return "[" + ", ".join(_stringify_value(x) for x in value) + "]"
+    return _stringify_value(value)
+
+
+def stringify(msg_defs: List[MessageDefinition]) -> str:
+    lines: List[str] = []
+    for i, msg_def in enumerate(msg_defs):
+        constants = [d for d in msg_def.definitions if getattr(d, "is_constant", False)]
+        variables = [
+            d for d in msg_def.definitions if not getattr(d, "is_constant", False)
+        ]
+
+        if i > 0:
+            lines.append("")
+            lines.append("=" * 80)
+            lines.append(f"MSG: {msg_def.name or ''}")
+        for const in constants:
+            value = (
+                const.value_text
+                if const.value_text is not None
+                else _stringify_value(const.value)
+            )
+            lines.append(f"{const.type} {const.name} = {value}")
+        if variables:
+            if lines:
+                lines.append("")
+            for var in variables:
+                upper_bound = (
+                    f"<={var.upper_bound}" if var.upper_bound is not None else ""
+                )
+                if var.array_length is not None:
+                    array_len = str(var.array_length)
+                elif var.array_upper_bound is not None:
+                    array_len = f"<={var.array_upper_bound}"
+                else:
+                    array_len = ""
+                array_suffix = (
+                    f"[{array_len}]" if getattr(var, "is_array", False) else ""
+                )
+                default_value = (
+                    f" {stringify_default_value(var.default_value)}"
+                    if var.default_value is not None
+                    else ""
+                )
+                lines.append(
+                    f"{var.type}{upper_bound}{array_suffix} {var.name}{default_value}"
+                )
+    return "\n".join(lines).rstrip()

--- a/python_ros/tests/test_stringify.py
+++ b/python_ros/tests/test_stringify.py
@@ -1,0 +1,82 @@
+from python_ros.rosmsg import parse, stringify
+
+
+def test_round_trip_definition():
+    message_definition = (
+        "uint32 foo = 55\n"
+        "int32 bar=-11 # Comment # another comment\n"
+        "string test\n"
+        "float32 baz= \t -32.25\n"
+        "bool someBoolean = 0\n"
+        "Point[] points\n"
+        "int64 A = 0000000000000001\n"
+        "string fooStr = Foo    \n"
+        'string EXAMPLE="Hello world"\n'
+        "===============\n"
+        "MSG: geometry_msgs/Point\n"
+        "float64 x"
+    )
+    types = parse(message_definition)
+    output = stringify(types)
+    assert (
+        output == "uint32 foo = 55\n"
+        "int32 bar = -11\n"
+        "float32 baz = -32.25\n"
+        "bool someBoolean = 0\n"
+        "int64 A = 0000000000000001\n"
+        "string fooStr = Foo\n"
+        'string EXAMPLE = "Hello world"\n'
+        "\n"
+        "string test\n"
+        "geometry_msgs/Point[] points\n"
+        "\n"
+        "================================================================================\n"  # noqa: E501
+        "MSG: geometry_msgs/Point\n"
+        "\n"
+        "float64 x"
+    )
+
+
+def test_ros2_features():
+    message_definition = (
+        "string<=5 str1 'abc'\n"
+        'string str2 "def"\n'
+        "int8[<=2] arr1 [ 1 ,-1 ]    \n"
+        "string<=1[<=3] arr2   # comment\n"
+        "bool a  true\n"
+        "float32 b  -1.0\n"
+        "float64 c  42.42\n"
+        "int8 d -100\n"
+        "uint8 e 100\n"
+        "int16 f -1000\n"
+        "uint16 g 1000\n"
+        "int32 h -100000\n"
+        "uint32 i 100000\n"
+        "int64 j -5000000000\n"
+        "uint64 k 5000000000\n"
+        'string my_string1 "I heard \\"Hello\\""# is valid\n'
+        "string my_string2 \"I heard 'Hello'\" # is valid\n"
+        "string my_string4 'I heard \"Hello\"'   # is valid\n"
+    )
+    types = parse(message_definition, ros2=True)
+    output = stringify(types)
+    assert (
+        output == 'string<=5 str1 "abc"\n'
+        'string str2 "def"\n'
+        "int8[<=2] arr1 [1, -1]\n"
+        "string<=1[<=3] arr2\n"
+        "bool a true\n"
+        "float32 b -1\n"
+        "float64 c 42.42\n"
+        "int8 d -100\n"
+        "uint8 e 100\n"
+        "int16 f -1000\n"
+        "uint16 g 1000\n"
+        "int32 h -100000\n"
+        "uint32 i 100000\n"
+        "int64 j -5000000000\n"
+        "uint64 k 5000000000\n"
+        'string my_string1 "I heard \\"Hello\\""\n'
+        "string my_string2 \"I heard 'Hello'\"\n"
+        'string my_string4 "I heard \\"Hello\\""'
+    )


### PR DESCRIPTION
## Summary
- implement ROS message definition canonical stringifier in Python
- expose stringify alongside existing parse utilities
- add tests covering ROS1 and ROS2 round-trip parse/stringify behavior

## Testing
- `pre-commit run --files python_ros/rosmsg/stringify.py python_ros/rosmsg/__init__.py python_ros/tests/test_stringify.py`
- `pytest python_ros/tests/test_stringify.py python_ros/tests/test_md5.py python_ros/tests/test_parse_ros1.py python_ros/tests/test_parse_ros2.py python_ros/tests/test_rostime.py`


------
https://chatgpt.com/codex/tasks/task_e_6891fcbe65c883308218256d831bd879