### PR TITLE
feat: add ROS 2 message serialization in Python

### DIFF
--- a/python_ros/rosmsg2_serialization/__init__.py
+++ b/python_ros/rosmsg2_serialization/__init__.py
@@ -1,0 +1,10 @@
+from .message_definition_has_data_fields import message_definition_has_data_fields
+from .message_reader import MessageReader, MessageReaderOptions
+from .message_writer import MessageWriter
+
+__all__ = [
+    "MessageReader",
+    "MessageReaderOptions",
+    "MessageWriter",
+    "message_definition_has_data_fields",
+]

--- a/python_ros/rosmsg2_serialization/message_definition_has_data_fields.py
+++ b/python_ros/rosmsg2_serialization/message_definition_has_data_fields.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from message_definition import MessageDefinitionField
+
+
+def message_definition_has_data_fields(
+    fields: Sequence[MessageDefinitionField],
+) -> bool:
+    """Return True if any field in the message definition is not a constant."""
+    return any(field.isConstant is not True for field in fields)

--- a/python_ros/rosmsg2_serialization/message_reader.py
+++ b/python_ros/rosmsg2_serialization/message_reader.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Mapping, MutableMapping, Sequence
+
+from message_definition import MessageDefinition, MessageDefinitionField
+
+from cdr import CdrReader
+
+from .message_definition_has_data_fields import message_definition_has_data_fields
+
+Ros1Time = Dict[str, int]
+Ros2Time = Dict[str, int]
+
+Deserializer = Callable[[CdrReader], Any]
+ArrayDeserializer = Callable[[CdrReader, int], Any]
+
+
+@dataclass
+class MessageReaderOptions:
+    timeType: str = "sec,nanosec"
+
+
+class MessageReader:
+    _root_definition: Sequence[MessageDefinitionField]
+    _definitions: Mapping[str, Sequence[MessageDefinitionField]]
+    _use_ros1_time: bool
+
+    def __init__(
+        self,
+        definitions: Sequence[MessageDefinition],
+        options: MessageReaderOptions | None = None,
+    ):
+        opts = options or MessageReaderOptions()
+        time_type = opts.timeType
+
+        # ros2idl modules could have constant modules before the root struct
+        root_def = next((d for d in definitions if not _is_constant_module(d)), None)
+        if root_def is None:
+            raise ValueError("MessageReader initialized with no root MessageDefinition")
+        self._root_definition = root_def.definitions
+        self._definitions = {d.name or "": d.definitions for d in definitions}
+        self._use_ros1_time = time_type == "sec,nsec"
+
+    def read_message(self, buffer: bytes | bytearray | memoryview) -> Any:
+        reader = CdrReader(buffer)
+        return self._read_complex_type(self._root_definition, reader)
+
+    def _read_complex_type(
+        self, definition: Sequence[MessageDefinitionField], reader: CdrReader
+    ) -> MutableMapping[str, Any]:
+        msg: MutableMapping[str, Any] = {}
+
+        if not message_definition_has_data_fields(definition):
+            # For empty message definitions ROS2 adds a uint8 placeholder
+            reader.uint8()
+            return msg
+
+        for field in definition:
+            if field.isConstant is True:
+                continue
+            if field.isComplex is True:
+                nested_def = self._definitions.get(field.type)
+                if nested_def is None:
+                    raise ValueError(f"Unrecognized complex type {field.type}")
+                if field.isArray:
+                    array_len = field.arrayLength or reader.sequence_length()
+                    array: List[Any] = []
+                    for _ in range(array_len):
+                        array.append(self._read_complex_type(nested_def, reader))
+                    msg[field.name] = array
+                else:
+                    msg[field.name] = self._read_complex_type(nested_def, reader)
+            else:
+                if field.isArray:
+                    deser = (
+                        _ros1_typed_array_deserializers
+                        if self._use_ros1_time
+                        else _typed_array_deserializers
+                    ).get(field.type)
+                    if deser is None:
+                        raise ValueError(
+                            f"Unrecognized primitive array type {field.type}[]"
+                        )
+                    array_len = field.arrayLength or reader.sequence_length()
+                    msg[field.name] = deser(reader, array_len)
+                else:
+                    deser = (
+                        _ros1_deserializers if self._use_ros1_time else _deserializers
+                    ).get(field.type)
+                    if deser is None:
+                        raise ValueError(f"Unrecognized primitive type {field.type}")
+                    msg[field.name] = deser(reader)
+        return msg
+
+
+def _is_constant_module(defn: MessageDefinition) -> bool:
+    return len(defn.definitions) > 0 and all(f.isConstant for f in defn.definitions)
+
+
+def _read_bool_array(reader: CdrReader, count: int) -> List[bool]:
+    data = reader.int8_array(count)
+    return [bool(x) for x in data]
+
+
+def _read_string_array(reader: CdrReader, count: int) -> List[str]:
+    # CdrReader already supports string_array
+    return list(reader.string_array(count))
+
+
+def _read_ros1_time_array(reader: CdrReader, count: int) -> List[Ros1Time]:
+    arr: List[Ros1Time] = []
+    for _ in range(count):
+        sec = reader.int32()
+        nsec = reader.uint32()
+        arr.append({"sec": sec, "nsec": nsec})
+    return arr
+
+
+def _read_time_array(reader: CdrReader, count: int) -> List[Ros2Time]:
+    arr: List[Ros2Time] = []
+    for _ in range(count):
+        sec = reader.int32()
+        nanosec = reader.uint32()
+        arr.append({"sec": sec, "nanosec": nanosec})
+    return arr
+
+
+def _throw_on_wstring(*_args: Any, **_kwargs: Any) -> Any:
+    raise RuntimeError("wstring is implementation-defined and therefore not supported")
+
+
+_deserializers: Dict[str, Deserializer] = {
+    "bool": lambda r: bool(r.int8()),
+    "int8": lambda r: r.int8(),
+    "uint8": lambda r: r.uint8(),
+    "int16": lambda r: r.int16(),
+    "uint16": lambda r: r.uint16(),
+    "int32": lambda r: r.int32(),
+    "uint32": lambda r: r.uint32(),
+    "int64": lambda r: r.int64(),
+    "uint64": lambda r: r.uint64(),
+    "float32": lambda r: r.float32(),
+    "float64": lambda r: r.float64(),
+    "string": lambda r: r.string(),
+    "wstring": _throw_on_wstring,
+    "time": lambda r: {"sec": r.int32(), "nanosec": r.uint32()},
+    "duration": lambda r: {"sec": r.int32(), "nanosec": r.uint32()},
+}
+
+_ros1_deserializers: Dict[str, Deserializer] = dict(_deserializers)
+_ros1_deserializers.update(
+    {
+        "time": lambda r: {"sec": r.int32(), "nsec": r.uint32()},
+        "duration": lambda r: {"sec": r.int32(), "nsec": r.uint32()},
+    }
+)
+
+_typed_array_deserializers: Dict[str, ArrayDeserializer] = {
+    "bool": _read_bool_array,
+    "int8": lambda r, c: list(r.int8_array(c)),
+    "uint8": lambda r, c: list(r.uint8_array(c)),
+    "int16": lambda r, c: list(r.int16_array(c)),
+    "uint16": lambda r, c: list(r.uint16_array(c)),
+    "int32": lambda r, c: list(r.int32_array(c)),
+    "uint32": lambda r, c: list(r.uint32_array(c)),
+    "int64": lambda r, c: list(r.int64_array(c)),
+    "uint64": lambda r, c: list(r.uint64_array(c)),
+    "float32": lambda r, c: list(r.float32_array(c)),
+    "float64": lambda r, c: list(r.float64_array(c)),
+    "string": _read_string_array,
+    "wstring": _throw_on_wstring,
+    "time": _read_time_array,
+    "duration": _read_time_array,
+}
+
+_ros1_typed_array_deserializers: Dict[str, ArrayDeserializer] = dict(
+    _typed_array_deserializers
+)
+_ros1_typed_array_deserializers.update(
+    {"time": _read_ros1_time_array, "duration": _read_ros1_time_array}
+)
+
+__all__ = ["MessageReader", "MessageReaderOptions"]

--- a/python_ros/rosmsg2_serialization/message_writer.py
+++ b/python_ros/rosmsg2_serialization/message_writer.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Mapping, Sequence
+
+from message_definition import DefaultValue, MessageDefinition, MessageDefinitionField
+
+from cdr import CdrWriter
+
+from .message_definition_has_data_fields import message_definition_has_data_fields
+
+PrimitiveWriter = Callable[[Any, DefaultValue, CdrWriter, int | None], None]
+PrimitiveArrayWriter = Callable[[Any, DefaultValue, CdrWriter, int | None], None]
+
+PRIMITIVE_SIZES: Dict[str, int] = {
+    "bool": 1,
+    "int8": 1,
+    "uint8": 1,
+    "int16": 2,
+    "uint16": 2,
+    "int32": 4,
+    "uint32": 4,
+    "int64": 8,
+    "uint64": 8,
+    "float32": 4,
+    "float64": 8,
+    "time": 8,
+    "duration": 8,
+}
+
+
+def throw_on_wstring(*_args: Any, **_kwargs: Any) -> None:
+    raise RuntimeError("wstring is implementation-defined and therefore not supported")
+
+
+# Primitive value writers -----------------------------------------------------
+
+
+def bool_(
+    value: Any, default: DefaultValue, writer: CdrWriter, _len: int | None = None
+) -> None:
+    val = bool(value) if isinstance(value, bool) else bool(default or False)
+    writer.int8(1 if val else 0)
+
+
+def int8_(
+    value: Any, default: DefaultValue, writer: CdrWriter, _len: int | None = None
+) -> None:
+    writer.int8(int(value if isinstance(value, (int,)) else default or 0))
+
+
+def uint8_(
+    value: Any, default: DefaultValue, writer: CdrWriter, _len: int | None = None
+) -> None:
+    writer.uint8(int(value if isinstance(value, (int,)) else default or 0))
+
+
+def int16_(
+    value: Any, default: DefaultValue, writer: CdrWriter, _len: int | None = None
+) -> None:
+    writer.int16(int(value if isinstance(value, (int,)) else default or 0))
+
+
+def uint16_(
+    value: Any, default: DefaultValue, writer: CdrWriter, _len: int | None = None
+) -> None:
+    writer.uint16(int(value if isinstance(value, (int,)) else default or 0))
+
+
+def int32_(
+    value: Any, default: DefaultValue, writer: CdrWriter, _len: int | None = None
+) -> None:
+    writer.int32(int(value if isinstance(value, (int,)) else default or 0))
+
+
+def uint32_(
+    value: Any, default: DefaultValue, writer: CdrWriter, _len: int | None = None
+) -> None:
+    writer.uint32(int(value if isinstance(value, (int,)) else default or 0))
+
+
+def int64_(
+    value: Any, default: DefaultValue, writer: CdrWriter, _len: int | None = None
+) -> None:
+    if isinstance(value, int):
+        writer.int64(value)
+    else:
+        writer.int64(int(default or 0))
+
+
+def uint64_(
+    value: Any, default: DefaultValue, writer: CdrWriter, _len: int | None = None
+) -> None:
+    if isinstance(value, int):
+        writer.uint64(value)
+    else:
+        writer.uint64(int(default or 0))
+
+
+def float32_(
+    value: Any, default: DefaultValue, writer: CdrWriter, _len: int | None = None
+) -> None:
+    writer.float32(float(value if isinstance(value, (int, float)) else default or 0.0))
+
+
+def float64_(
+    value: Any, default: DefaultValue, writer: CdrWriter, _len: int | None = None
+) -> None:
+    writer.float64(float(value if isinstance(value, (int, float)) else default or 0.0))
+
+
+def string_(
+    value: Any, default: DefaultValue, writer: CdrWriter, _len: int | None = None
+) -> None:
+    writer.string(str(value) if isinstance(value, str) else str(default or ""))
+
+
+def time_(
+    value: Any, _default: DefaultValue, writer: CdrWriter, _len: int | None = None
+) -> None:
+    if value is None:
+        writer.int32(0)
+        writer.uint32(0)
+    else:
+        obj = value if isinstance(value, Mapping) else {}
+        writer.int32(int(obj.get("sec", 0)))
+        writer.uint32(int(obj.get("nsec", obj.get("nanosec", 0))))
+
+
+PRIMITIVE_WRITERS: Dict[str, PrimitiveWriter] = {
+    "bool": bool_,
+    "int8": int8_,
+    "uint8": uint8_,
+    "int16": int16_,
+    "uint16": uint16_,
+    "int32": int32_,
+    "uint32": uint32_,
+    "int64": int64_,
+    "uint64": uint64_,
+    "float32": float32_,
+    "float64": float64_,
+    "string": string_,
+    "time": time_,
+    "duration": time_,
+    "wstring": throw_on_wstring,
+}
+
+
+# Primitive array writers -----------------------------------------------------
+
+
+def bool_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_len: int | None = None
+) -> None:
+    if isinstance(value, Sequence):
+        writer.int8Array([1 if bool(v) else 0 for v in value])
+    else:
+        writer.int8Array(
+            [1 if bool(v) else 0 for v in (default or [0] * (array_len or 0))]
+        )
+
+
+def int8_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_len: int | None = None
+) -> None:
+    if isinstance(value, Sequence):
+        writer.int8Array(list(value))
+    else:
+        writer.int8Array(list(default or [0] * (array_len or 0)))
+
+
+def uint8_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_len: int | None = None
+) -> None:
+    if isinstance(value, (bytes, bytearray)):
+        writer.uint8Array(value)
+    elif isinstance(value, Sequence):
+        writer.uint8Array(list(value))
+    else:
+        writer.uint8Array(list(default or [0] * (array_len or 0)))
+
+
+def int16_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_len: int | None = None
+) -> None:
+    if isinstance(value, Sequence):
+        writer.int16Array(list(value))
+    else:
+        writer.int16Array(list(default or [0] * (array_len or 0)))
+
+
+def uint16_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_len: int | None = None
+) -> None:
+    if isinstance(value, Sequence):
+        writer.uint16Array(list(value))
+    else:
+        writer.uint16Array(list(default or [0] * (array_len or 0)))
+
+
+def int32_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_len: int | None = None
+) -> None:
+    if isinstance(value, Sequence):
+        writer.int32Array(list(value))
+    else:
+        writer.int32Array(list(default or [0] * (array_len or 0)))
+
+
+def uint32_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_len: int | None = None
+) -> None:
+    if isinstance(value, Sequence):
+        writer.uint32Array(list(value))
+    else:
+        writer.uint32Array(list(default or [0] * (array_len or 0)))
+
+
+def int64_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_len: int | None = None
+) -> None:
+    if isinstance(value, Sequence):
+        writer.int64Array(list(value))
+    else:
+        writer.int64Array(list(default or [0] * (array_len or 0)))
+
+
+def uint64_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_len: int | None = None
+) -> None:
+    if isinstance(value, Sequence):
+        writer.uint64Array(list(value))
+    else:
+        writer.uint64Array(list(default or [0] * (array_len or 0)))
+
+
+def float32_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_len: int | None = None
+) -> None:
+    if isinstance(value, Sequence):
+        writer.float32Array(list(value))
+    else:
+        writer.float32Array(list(default or [0.0] * (array_len or 0)))
+
+
+def float64_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_len: int | None = None
+) -> None:
+    if isinstance(value, Sequence):
+        writer.float64Array(list(value))
+    else:
+        writer.float64Array(list(default or [0.0] * (array_len or 0)))
+
+
+def string_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_len: int | None = None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            writer.string(str(item) if isinstance(item, str) else "")
+    else:
+        arr = list(default or [""] * (array_len or 0))
+        for item in arr:
+            writer.string(item)
+
+
+def time_array(
+    value: Any, default: DefaultValue, writer: CdrWriter, array_len: int | None = None
+) -> None:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            time_(item, None, writer)
+    else:
+        arr = [None] * (array_len or 0)
+        for item in arr:
+            time_(item, None, writer)
+
+
+PRIMITIVE_ARRAY_WRITERS: Dict[str, PrimitiveArrayWriter] = {
+    "bool": bool_array,
+    "int8": int8_array,
+    "uint8": uint8_array,
+    "int16": int16_array,
+    "uint16": uint16_array,
+    "int32": int32_array,
+    "uint32": uint32_array,
+    "int64": int64_array,
+    "uint64": uint64_array,
+    "float32": float32_array,
+    "float64": float64_array,
+    "string": string_array,
+    "time": time_array,
+    "duration": time_array,
+    "wstring": throw_on_wstring,
+}
+
+
+class MessageWriter:
+    _root_definition: Sequence[MessageDefinitionField]
+    _definitions: Mapping[str, Sequence[MessageDefinitionField]]
+
+    def __init__(self, definitions: Sequence[MessageDefinition]):
+        root_def = next((d for d in definitions if not _is_constant_module(d)), None)
+        if root_def is None:
+            raise ValueError("MessageReader initialized with no root MessageDefinition")
+        self._root_definition = root_def.definitions
+        self._definitions = {d.name or "": d.definitions for d in definitions}
+
+    def calculate_byte_size(self, message: Any) -> int:
+        return self._byte_size(self._root_definition, message, 4)
+
+    def write_message(self, message: Any, output: bytearray | None = None) -> bytes:
+        writer = CdrWriter(buffer=output) if output is not None else CdrWriter()
+        self._write(self._root_definition, message, writer)
+        return bytes(writer.data)
+
+    # Internal helpers -----------------------------------------------------
+
+    def _byte_size(
+        self, definition: Sequence[MessageDefinitionField], message: Any, offset: int
+    ) -> int:
+        msg = message or {}
+        new_offset = offset
+
+        if not message_definition_has_data_fields(definition):
+            return offset + self._get_primitive_size("uint8")
+
+        for field in definition:
+            if field.isConstant:
+                continue
+            nested_msg = msg.get(field.name)
+            if field.isArray:
+                array_length = field.arrayLength or _field_length(nested_msg)
+                data_is_array = isinstance(nested_msg, Sequence) and not isinstance(
+                    nested_msg, (str, bytes, bytearray)
+                )
+                data_array = nested_msg if data_is_array else []
+
+                if field.arrayLength is None:
+                    new_offset += _padding(new_offset, 4)
+                    new_offset += 4
+
+                if field.isComplex:
+                    nested_def = self._get_definition(field.type)
+                    for i in range(array_length):
+                        entry = data_array[i] if i < len(data_array) else {}
+                        new_offset = self._byte_size(nested_def, entry, new_offset)
+                elif field.type == "string":
+                    for i in range(array_length):
+                        entry = data_array[i] if i < len(data_array) else ""
+                        new_offset += _padding(new_offset, 4)
+                        new_offset += 4 + len(entry) + 1
+                else:
+                    entry_size = self._get_primitive_size(field.type)
+                    alignment = 4 if field.type in ("time", "duration") else entry_size
+                    new_offset += _padding(new_offset, alignment)
+                    new_offset += entry_size * array_length
+            else:
+                if field.isComplex:
+                    nested_def = self._get_definition(field.type)
+                    entry = nested_msg or {}
+                    new_offset = self._byte_size(nested_def, entry, new_offset)
+                elif field.type == "string":
+                    entry = nested_msg if isinstance(nested_msg, str) else ""
+                    new_offset += _padding(new_offset, 4)
+                    new_offset += 4 + len(entry) + 1
+                else:
+                    entry_size = self._get_primitive_size(field.type)
+                    alignment = 4 if field.type in ("time", "duration") else entry_size
+                    new_offset += _padding(new_offset, alignment)
+                    new_offset += entry_size
+        return new_offset
+
+    def _write(
+        self,
+        definition: Sequence[MessageDefinitionField],
+        message: Any,
+        writer: CdrWriter,
+    ) -> None:
+        msg = message or {}
+
+        if not message_definition_has_data_fields(definition):
+            uint8_(0, 0, writer)
+            return
+
+        for field in definition:
+            if field.isConstant:
+                continue
+            nested_msg = msg.get(field.name)
+            if field.isArray:
+                array_length = field.arrayLength or _field_length(nested_msg)
+                data_is_array = isinstance(nested_msg, Sequence) and not isinstance(
+                    nested_msg, (str, bytes, bytearray)
+                )
+                data_array = nested_msg if data_is_array else []
+                if field.arrayLength is None:
+                    writer.sequenceLength(array_length)
+                if field.arrayLength is not None and nested_msg is not None:
+                    given_length = _field_length(nested_msg)
+                    if given_length != field.arrayLength:
+                        raise ValueError(
+                            (
+                                "Expected "
+                                f"{field.arrayLength} items for fixed-length "
+                                "array field "
+                                f"{field.name} but "
+                                f"received {given_length}"
+                            )
+                        )
+                if field.isComplex:
+                    nested_def = self._get_definition(field.type)
+                    for i in range(array_length):
+                        entry = data_array[i] if i < len(data_array) else {}
+                        self._write(nested_def, entry, writer)
+                else:
+                    array_writer = self._get_primitive_array_writer(field.type)
+                    array_writer(
+                        nested_msg, field.defaultValue, writer, field.arrayLength
+                    )
+            else:
+                if field.isComplex:
+                    nested_def = self._get_definition(field.type)
+                    entry = nested_msg or {}
+                    self._write(nested_def, entry, writer)
+                else:
+                    prim_writer = self._get_primitive_writer(field.type)
+                    prim_writer(nested_msg, field.defaultValue, writer, None)
+
+    def _get_definition(self, datatype: str) -> Sequence[MessageDefinitionField]:
+        nested = self._definitions.get(datatype)
+        if nested is None:
+            raise ValueError(f"Unrecognized complex type {datatype}")
+        return nested
+
+    def _get_primitive_size(self, primitive: str) -> int:
+        size = PRIMITIVE_SIZES.get(primitive)
+        if size is None:
+            if primitive == "wstring":
+                throw_on_wstring()
+            raise ValueError(f"Unrecognized primitive type {primitive}")
+        return size
+
+    def _get_primitive_writer(self, primitive: str) -> PrimitiveWriter:
+        writer = PRIMITIVE_WRITERS.get(primitive)
+        if writer is None:
+            raise ValueError(f"Unrecognized primitive type {primitive}")
+        return writer
+
+    def _get_primitive_array_writer(self, primitive: str) -> PrimitiveArrayWriter:
+        writer = PRIMITIVE_ARRAY_WRITERS.get(primitive)
+        if writer is None:
+            raise ValueError(f"Unrecognized primitive type {primitive}[]")
+        return writer
+
+
+def _is_constant_module(defn: MessageDefinition) -> bool:
+    return len(defn.definitions) > 0 and all(f.isConstant for f in defn.definitions)
+
+
+def _field_length(value: Any) -> int:
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return len(value)
+    return 0
+
+
+def _padding(offset: int, byte_width: int) -> int:
+    alignment = (offset - 4) % byte_width
+    return byte_width - alignment if alignment > 0 else 0
+
+
+__all__ = ["MessageWriter"]

--- a/python_ros/tests/test_rosmsg2_serialization.py
+++ b/python_ros/tests/test_rosmsg2_serialization.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from rosmsg import parse
+from rosmsg2_serialization import MessageReader, MessageWriter
+
+
+def roundtrip(def_text: str, message: dict) -> bytes:
+    defs = parse(def_text)
+    writer = MessageWriter(defs)
+    data = writer.write_message(message)
+    reader = MessageReader(defs)
+    assert reader.read_message(data) == message
+    return data
+
+
+def test_primitives_round_trip():
+    roundtrip("int8 sample", {"sample": -12})
+    roundtrip("uint32 count", {"count": 4294967295})
+    roundtrip("float64 value", {"value": 0.125})
+
+
+def test_arrays_round_trip():
+    roundtrip("int32[] values", {"values": [3, 7]})
+    roundtrip("float32[2] arr", {"arr": [1.5, 2.5]})
+    roundtrip("string[] names", {"names": ["one", "two"]})
+
+
+def test_complex_round_trip():
+    definition = (
+        "CustomType custom\n"
+        "===============\n"
+        "MSG: custom_type/CustomType\n"
+        "uint8 first"
+    )
+    roundtrip(definition, {"custom": {"first": 2}})
+
+
+def test_ignores_constants():
+    definition = "int8 A=1\nint8 value"
+    roundtrip(definition, {"value": 2})
+
+
+def test_time_round_trip():
+    definition = "time stamp"
+    msg = {"stamp": {"sec": 1, "nanosec": 2}}
+    roundtrip(definition, msg)


### PR DESCRIPTION
## Summary
- port rosmsg2-serialization to Python using python CDR library
- support reading and writing ROS 2 messages
- add round-trip tests for primitives, arrays, complex types, and time fields

## Testing
- `pre-commit run --files python_ros/rosmsg2_serialization/__init__.py python_ros/rosmsg2_serialization/message_definition_has_data_fields.py python_ros/rosmsg2_serialization/message_reader.py python_ros/rosmsg2_serialization/message_writer.py python_ros/tests/test_rosmsg2_serialization.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898bbe708ac8330824d93c256a05230