### PR TITLE
feat(python): add union message reading

### DIFF
--- a/python_ros/ros2idl_parser/__init__.py
+++ b/python_ros/ros2idl_parser/__init__.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 from typing import List
 
-from message_definition import MessageDefinition, MessageDefinitionField
-from omgidl_parser import parse_idl_message_definitions
+from message_definition import MessageDefinitionField
+from omgidl_parser import (
+    Case,
+    IDLMessageDefinition,
+    IDLModuleDefinition,
+    IDLStructDefinition,
+    IDLUnionDefinition,
+    parse_idl_message_definitions,
+)
 
 
-def parse_ros2idl(text: str) -> List[MessageDefinition]:
-    """Parse ROS 2 IDL text into MessageDefinition objects."""
+def parse_ros2idl(text: str) -> List[IDLMessageDefinition]:
+    """Parse ROS 2 IDL text into message definition objects."""
 
     blocks: List[str] = []
     current: List[str] = []
@@ -29,17 +36,60 @@ def parse_ros2idl(text: str) -> List[MessageDefinition]:
     def convert_name(name: str | None) -> str | None:
         return name.replace("::", "/") if name else None
 
-    definitions: List[MessageDefinition] = []
+    definitions: List[IDLMessageDefinition] = []
     for defn in idl_defs:
-        fields = [
-            MessageDefinitionField(**{**vars(f), "type": convert_name(f.type)})
-            for f in defn.definitions
-        ]
-        definitions.append(
-            MessageDefinition(name=convert_name(defn.name), definitions=fields)
-        )
+        if isinstance(defn, IDLUnionDefinition):
+            cases: List[Case] = []
+            for c in defn.cases:
+                field = MessageDefinitionField(
+                    **{**vars(c.type), "type": convert_name(c.type.type)}
+                )
+                cases.append(Case(predicates=list(c.predicates), type=field))
+
+            default_case = None
+            if defn.defaultCase is not None:
+                default_case = MessageDefinitionField(
+                    **{
+                        **vars(defn.defaultCase),
+                        "type": convert_name(defn.defaultCase.type),
+                    }
+                )
+
+            definitions.append(
+                IDLUnionDefinition(
+                    name=convert_name(defn.name) or "",
+                    switchType=convert_name(defn.switchType) or "",
+                    cases=cases,
+                    defaultCase=default_case,
+                    annotations=defn.annotations,
+                )
+            )
+        else:
+            fields = [
+                MessageDefinitionField(**{**vars(f), "type": convert_name(f.type)})
+                for f in defn.definitions
+            ]
+            name = convert_name(defn.name)
+            if isinstance(defn, IDLModuleDefinition):
+                definitions.append(
+                    IDLModuleDefinition(
+                        name=name or "",
+                        definitions=fields,
+                        annotations=defn.annotations,
+                    )
+                )
+            else:
+                definitions.append(
+                    IDLStructDefinition(
+                        name=name or "",
+                        definitions=fields,
+                        annotations=defn.annotations,
+                    )
+                )
 
     return definitions
 
 
-__all__ = ["parse_ros2idl"]
+__all__ = [
+    "parse_ros2idl",
+]

--- a/python_ros/rosmsg2_serialization/MessageReader.py
+++ b/python_ros/rosmsg2_serialization/MessageReader.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Mapping, Sequence
 
 from message_definition import MessageDefinition, MessageDefinitionField
+from omgidl_parser import IDLMessageDefinition, IDLUnionDefinition
 
 from cdr import CdrReader
 
@@ -22,13 +23,13 @@ class MessageReaderOptions:
 
 
 class MessageReader:
-    _root_definition: List[MessageDefinitionField]
-    _definitions: Mapping[str, List[MessageDefinitionField]]
+    _root_definition: Any
+    _definitions: Mapping[str, Any]
     _use_ros1_time: bool
 
     def __init__(
         self,
-        definitions: Sequence[MessageDefinition],
+        definitions: Sequence[MessageDefinition | IDLMessageDefinition],
         options: MessageReaderOptions | None = None,
     ) -> None:
         opts = options or MessageReaderOptions()
@@ -37,17 +38,41 @@ class MessageReader:
         # ros2idl modules could have constant modules before the root struct used
         # to decode message
         root_definition = next(
-            (d for d in definitions if not _is_constant_module(d)), None
+            (
+                d
+                for d in definitions
+                if hasattr(d, "definitions") and not _is_constant_module(d)
+            ),
+            None,
         )
         if root_definition is None:
+            root_definition = next(
+                (d for d in definitions if isinstance(d, IDLUnionDefinition)), None
+            )
+        if root_definition is None:
             raise ValueError("MessageReader initialized with no root MessageDefinition")
-        self._root_definition = list(root_definition.definitions)
-        self._definitions = {d.name or "": list(d.definitions) for d in definitions}
+        if hasattr(root_definition, "definitions"):
+            self._root_definition = list(root_definition.definitions)
+        else:
+            self._root_definition = root_definition
+        defs: Dict[str, Any] = {}
+        for d in definitions:
+            name = getattr(d, "name", "") or ""
+            if isinstance(d, IDLUnionDefinition):
+                defs[name] = d
+            else:
+                defs[name] = list(d.definitions)
+        self._definitions = defs
         self._use_ros1_time = time_type == "sec,nsec"
 
     def read_message(self, buffer: bytes | bytearray | memoryview) -> Any:
         reader = CdrReader(buffer)
-        return self._read_complex_type(self._root_definition, reader)
+        return self._read_definition(self._root_definition, reader)
+
+    def _read_definition(self, definition: Any, reader: CdrReader) -> Any:
+        if isinstance(definition, IDLUnionDefinition):
+            return self._read_union(definition, reader)
+        return self._read_complex_type(definition, reader)
 
     def _read_complex_type(
         self, definition: Sequence[MessageDefinitionField], reader: CdrReader
@@ -73,10 +98,10 @@ class MessageReader:
                     array_length = field.arrayLength or reader.sequence_length()
                     array = []
                     for _ in range(array_length):
-                        array.append(self._read_complex_type(nested_definition, reader))
+                        array.append(self._read_definition(nested_definition, reader))
                     msg[field.name] = array
                 else:
-                    msg[field.name] = self._read_complex_type(nested_definition, reader)
+                    msg[field.name] = self._read_definition(nested_definition, reader)
             else:
                 if field.isArray is True:
                     deser_map = (
@@ -102,9 +127,67 @@ class MessageReader:
 
         return msg
 
+    def _read_union(
+        self, defn: IDLUnionDefinition, reader: CdrReader
+    ) -> Dict[str, Any]:
+        deser_map = _ros1_deserializers if self._use_ros1_time else _deserializers
+        deser = deser_map.get(defn.switchType)
+        if deser is None:
+            raise ValueError(f"Unrecognized primitive type {defn.switchType}")
+        switch_val = deser(reader)
 
-def _is_constant_module(defn: MessageDefinition) -> bool:
-    return len(defn.definitions) > 0 and all(f.isConstant for f in defn.definitions)
+        field_def: MessageDefinitionField | None = None
+        for case in defn.cases:
+            if switch_val in case.predicates:
+                field_def = case.type
+                break
+        if field_def is None:
+            field_def = defn.defaultCase
+        if field_def is None:
+            return {}
+
+        value: Any
+        if field_def.isComplex:
+            nested_definition = self._definitions.get(field_def.type)
+            if nested_definition is None:
+                raise ValueError(f"Unrecognized complex type {field_def.type}")
+            if field_def.isArray is True:
+                array_length = field_def.arrayLength or reader.sequence_length()
+                value = [
+                    self._read_definition(nested_definition, reader)
+                    for _ in range(array_length)
+                ]
+            else:
+                value = self._read_definition(nested_definition, reader)
+        else:
+            if field_def.isArray is True:
+                deser_arr_map = (
+                    _ros1_typed_array_deserializers
+                    if self._use_ros1_time
+                    else _typed_array_deserializers
+                )
+                deser_arr = deser_arr_map.get(field_def.type)
+                if deser_arr is None:
+                    raise ValueError(
+                        f"Unrecognized primitive array type {field_def.type}[]"
+                    )
+                array_length = field_def.arrayLength or reader.sequence_length()
+                value = deser_arr(reader, array_length)
+            else:
+                deser_prim = deser_map.get(field_def.type)
+                if deser_prim is None:
+                    raise ValueError(f"Unrecognized primitive type {field_def.type}")
+                value = deser_prim(reader)
+
+        return {field_def.name: value}
+
+
+def _is_constant_module(defn: Any) -> bool:
+    return (
+        hasattr(defn, "definitions")
+        and len(defn.definitions) > 0
+        and all(f.isConstant for f in defn.definitions)
+    )
 
 
 def _read_bool_array(reader: CdrReader, count: int) -> List[bool]:

--- a/python_ros/tests/test_MessageReader.py
+++ b/python_ros/tests/test_MessageReader.py
@@ -6,6 +6,8 @@ from ros2idl_parser import parse_ros2idl
 from rosmsg2_serialization import MessageReader, MessageReaderOptions
 from rosmsg.parse import parse
 
+from cdr import CdrWriter
+
 
 def _serialize_string(string: str) -> bytes:
     data = string.encode("utf8")
@@ -477,3 +479,42 @@ def test_wstring_unsupported(msg_def: str) -> None:
     reader = MessageReader(defs)
     with pytest.raises(RuntimeError, match="wstring is implementation-defined"):
         reader.read_message(buffer)
+
+
+def test_union_parsing() -> None:
+    from python_ros.ros2idl_parser import parse_ros2idl as local_parse_ros2idl
+
+    msg_def = """module test {
+  union MyUnion switch (uint8) {
+    case 0: int32 i;
+    case 1: float32 f;
+    default: string s;
+  };
+  struct MyMsg {
+    MyUnion value;
+  };
+};
+"""
+    defs = local_parse_ros2idl(msg_def)
+    reader = MessageReader(defs)
+
+    w = CdrWriter()
+    w.reset_origin()
+    w.reset_origin()
+    w.uint8(0)
+    w.int32(42)
+    assert reader.read_message(w.data) == {"value": {"i": 42}}
+
+    w = CdrWriter()
+    w.reset_origin()
+    w.reset_origin()
+    w.uint8(1)
+    w.float32(1.5)
+    assert reader.read_message(w.data) == {"value": {"f": pytest.approx(1.5)}}
+
+    w = CdrWriter()
+    w.reset_origin()
+    w.reset_origin()
+    w.uint8(3)
+    w.string("hello")
+    assert reader.read_message(w.data) == {"value": {"s": "hello"}}


### PR DESCRIPTION
## Summary
- support unions from ros2idl_parser during Python message deserialization
- convert ros2idl_parser output into structured definitions with union cases
- test parsing of discriminated union fields

## Testing
- `pre-commit run --files python_ros/rosmsg2_serialization/MessageReader.py python_ros/tests/test_MessageReader.py python_ros/ros2idl_parser/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68999c08525c8330b5eb4ab567a525a6