### PR TITLE
Handle enums in MessageReader

### DIFF
--- a/python_ros/rosmsg2_serialization/MessageReader.py
+++ b/python_ros/rosmsg2_serialization/MessageReader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Mapping, Sequence
 
-from message_definition import MessageDefinition, MessageDefinitionField
+from message_definition import AggregatedKind, MessageDefinition, MessageDefinitionField
 
 from cdr import CdrReader
 
@@ -19,12 +19,16 @@ ArrayDeserializer = Callable[[CdrReader, int], Any]
 @dataclass
 class MessageReaderOptions:
     timeType: str = "sec,nanosec"  # "sec,nanosec" or "sec,nsec"
+    enumsAsStrings: bool = False
 
 
 class MessageReader:
-    _root_definition: List[MessageDefinitionField]
-    _definitions: Mapping[str, List[MessageDefinitionField]]
+    _root_definition: MessageDefinition
+    _definitions: Mapping[str, MessageDefinition]
     _use_ros1_time: bool
+    _enum_types: Dict[str, str]
+    _enum_mappings: Dict[str, Dict[int, str]]
+    _enums_as_strings: bool
 
     def __init__(
         self,
@@ -33,74 +37,161 @@ class MessageReader:
     ) -> None:
         opts = options or MessageReaderOptions()
         time_type = opts.timeType
+        self._enums_as_strings = opts.enumsAsStrings
 
         # ros2idl modules could have constant modules before the root struct used
-        # to decode message
+        # to decode message. Find the first struct definition to use as the root.
         root_definition = next(
-            (d for d in definitions if not _is_constant_module(d)), None
+            (
+                d
+                for d in definitions
+                if not _is_constant_module(d)
+                and d.aggregatedKind == AggregatedKind.STRUCT
+            ),
+            None,
         )
         if root_definition is None:
             raise ValueError("MessageReader initialized with no root MessageDefinition")
-        self._root_definition = list(root_definition.definitions)
-        self._definitions = {d.name or "": list(d.definitions) for d in definitions}
+        self._root_definition = root_definition
+        self._definitions = {d.name or "": d for d in definitions}
         self._use_ros1_time = time_type == "sec,nsec"
+
+        # Build enum mappings for constant modules so enum values can be
+        # converted to their named representation on read.
+        self._enum_types = {}
+        self._enum_mappings = {}
+        for defn in definitions:
+            if defn.name and _is_constant_module(defn):
+                if not defn.definitions:
+                    continue
+                base_type = defn.definitions[0].type
+                mapping: Dict[int, str] = {}
+                for f in defn.definitions:
+                    if f.value is not None:
+                        try:
+                            mapping[int(f.value)] = f.name
+                        except (TypeError, ValueError):
+                            continue
+                if mapping:
+                    self._enum_types[defn.name] = base_type
+                    self._enum_mappings[defn.name] = mapping
 
     def read_message(self, buffer: bytes | bytearray | memoryview) -> Any:
         reader = CdrReader(buffer)
         return self._read_complex_type(self._root_definition, reader)
 
     def _read_complex_type(
-        self, definition: Sequence[MessageDefinitionField], reader: CdrReader
+        self, definition: MessageDefinition, reader: CdrReader
     ) -> Dict[str, Any]:
+        if definition.aggregatedKind == AggregatedKind.UNION:
+            return self._read_union(definition, reader)
+
         msg: Dict[str, Any] = {}
 
-        if not message_definition_has_data_fields(definition):
+        if not message_definition_has_data_fields(definition.definitions):
             # In case a message definition definition is empty, ROS 2 adds a
             # `uint8 structure_needs_at_least_one_member` field when converting to IDL,
             # to satisfy the requirement from IDL of not being empty.
             reader.uint8()
             return msg
 
-        for field in definition:
+        for field in definition.definitions:
             if field.isConstant is True:
                 continue
-
-            if field.isComplex is True:
-                nested_definition = self._definitions.get(field.type)
-                if nested_definition is None:
-                    raise ValueError(f"Unrecognized complex type {field.type}")
-                if field.isArray is True:
-                    array_length = field.arrayLength or reader.sequence_length()
-                    array = []
-                    for _ in range(array_length):
-                        array.append(self._read_complex_type(nested_definition, reader))
-                    msg[field.name] = array
-                else:
-                    msg[field.name] = self._read_complex_type(nested_definition, reader)
-            else:
-                if field.isArray is True:
-                    deser_map = (
-                        _ros1_typed_array_deserializers
-                        if self._use_ros1_time
-                        else _typed_array_deserializers
-                    )
-                    deser = deser_map.get(field.type)
-                    if deser is None:
-                        raise ValueError(
-                            f"Unrecognized primitive array type {field.type}[]"
-                        )
-                    array_length = field.arrayLength or reader.sequence_length()
-                    msg[field.name] = deser(reader, array_length)
-                else:
-                    deser_map = (
-                        _ros1_deserializers if self._use_ros1_time else _deserializers
-                    )
-                    deser = deser_map.get(field.type)
-                    if deser is None:
-                        raise ValueError(f"Unrecognized primitive type {field.type}")
-                    msg[field.name] = deser(reader)
+            msg[field.name] = self._read_field_value(field, reader)
 
         return msg
+
+    def _read_field_value(
+        self, field: MessageDefinitionField, reader: CdrReader
+    ) -> Any:
+        if field.isComplex is True:
+            nested_definition = self._definitions.get(field.type)
+            if nested_definition is None:
+                raise ValueError(f"Unrecognized complex type {field.type}")
+            if field.isArray is True:
+                array_length = field.arrayLength or reader.sequence_length()
+                return [
+                    self._read_complex_type(nested_definition, reader)
+                    for _ in range(array_length)
+                ]
+            return self._read_complex_type(nested_definition, reader)
+
+        if field.isArray is True:
+            deser_map = (
+                _ros1_typed_array_deserializers
+                if self._use_ros1_time
+                else _typed_array_deserializers
+            )
+            if field.type in self._enum_types:
+                base_type = self._enum_types[field.type]
+                mapping = self._enum_mappings[field.type]
+                deser = deser_map.get(base_type)
+                if deser is None:
+                    raise ValueError(f"Unrecognized primitive array type {base_type}[]")
+                array_length = field.arrayLength or reader.sequence_length()
+                values = deser(reader, array_length)
+                if self._enums_as_strings:
+                    return [mapping.get(int(v), v) for v in values]
+                return list(values)
+            deser = deser_map.get(field.type)
+            if deser is None:
+                raise ValueError(f"Unrecognized primitive array type {field.type}[]")
+            array_length = field.arrayLength or reader.sequence_length()
+            return deser(reader, array_length)
+
+        deser_map = _ros1_deserializers if self._use_ros1_time else _deserializers
+        if field.type in self._enum_types:
+            base_type = self._enum_types[field.type]
+            mapping = self._enum_mappings[field.type]
+            deser = deser_map.get(base_type)
+            if deser is None:
+                raise ValueError(f"Unrecognized primitive type {base_type}")
+            value = deser(reader)
+            if self._enums_as_strings:
+                return mapping.get(int(value), value)
+            return value
+        deser = deser_map.get(field.type)
+        if deser is None:
+            raise ValueError(f"Unrecognized primitive type {field.type}")
+        return deser(reader)
+
+    def _read_union(
+        self, definition: MessageDefinition, reader: CdrReader
+    ) -> Dict[str, Any]:
+        discr_type = definition.switchType or ""
+        deser_map = _ros1_deserializers if self._use_ros1_time else _deserializers
+        mapping: Dict[int, str] | None = None
+        if discr_type in self._enum_types:
+            base_type = self._enum_types[discr_type]
+            mapping = self._enum_mappings[discr_type]
+        else:
+            base_type = discr_type
+        deser = deser_map.get(base_type)
+        if deser is None:
+            raise ValueError(f"Unrecognized union discriminator type {discr_type}")
+        raw_disc = deser(reader)
+        if mapping and self._enums_as_strings:
+            discriminator: Any = mapping.get(int(raw_disc), raw_disc)
+        else:
+            discriminator = raw_disc
+
+        field_for_case: MessageDefinitionField | None = None
+        default_field: MessageDefinitionField | None = None
+        for f in definition.definitions:
+            preds = f.casePredicates or []
+            if any(int(raw_disc) == int(p) for p in preds):
+                field_for_case = f
+                break
+            if f.isDefaultCase:
+                default_field = f
+        if field_for_case is None:
+            field_for_case = default_field
+
+        result: Dict[str, Any] = {"discriminator": discriminator}
+        if field_for_case is not None:
+            result[field_for_case.name] = self._read_field_value(field_for_case, reader)
+        return result
 
 
 def _is_constant_module(defn: MessageDefinition) -> bool:

--- a/python_ros/tests/test_message_reader_enum.py
+++ b/python_ros/tests/test_message_reader_enum.py
@@ -1,0 +1,47 @@
+from message_definition import MessageDefinition, MessageDefinitionField
+from rosmsg2_serialization import MessageReader, MessageReaderOptions
+
+from cdr import CdrWriter
+
+
+def make_defs():
+    enum_def = MessageDefinition(
+        name="Color",
+        definitions=[
+            MessageDefinitionField(type="uint8", name="RED", isConstant=True, value=0),
+            MessageDefinitionField(
+                type="uint8", name="GREEN", isConstant=True, value=1
+            ),
+            MessageDefinitionField(type="uint8", name="BLUE", isConstant=True, value=2),
+        ],
+    )
+    root_def = MessageDefinition(
+        name="MyMsg",
+        definitions=[
+            MessageDefinitionField(type="Color", name="color"),
+            MessageDefinitionField(type="Color", name="palette", isArray=True),
+        ],
+    )
+    return [enum_def, root_def]
+
+
+def make_buffer():
+    writer = CdrWriter()
+    writer.uint8(1)  # color = GREEN
+    writer.sequenceLength(2)
+    writer.uint8(0)  # palette[0] = RED
+    writer.uint8(2)  # palette[1] = BLUE
+    return writer.data
+
+
+def test_enum_values_as_ints():
+    reader = MessageReader(make_defs())
+    msg = reader.read_message(make_buffer())
+    assert msg == {"color": 1, "palette": [0, 2]}
+
+
+def test_enum_values_as_strings():
+    options = MessageReaderOptions(enumsAsStrings=True)
+    reader = MessageReader(make_defs(), options)
+    msg = reader.read_message(make_buffer())
+    assert msg == {"color": "GREEN", "palette": ["RED", "BLUE"]}

--- a/python_ros/tests/test_message_reader_union_enum.py
+++ b/python_ros/tests/test_message_reader_union_enum.py
@@ -1,0 +1,73 @@
+from message_definition import AggregatedKind, MessageDefinition, MessageDefinitionField
+from rosmsg2_serialization import MessageReader, MessageReaderOptions
+
+from cdr import CdrWriter
+
+
+def make_defs():
+    enum_def = MessageDefinition(
+        name="test/t2_test_msgs/FooEnum",
+        aggregatedKind=AggregatedKind.MODULE,
+        definitions=[
+            MessageDefinitionField(
+                type="uint32", name="ENUMERATOR1", isConstant=True, value=0
+            ),
+            MessageDefinitionField(
+                type="uint32", name="ENUMERATOR2", isConstant=True, value=1
+            ),
+        ],
+    )
+
+    union_def = MessageDefinition(
+        name="test/t2_test_msgs/FooUnion",
+        aggregatedKind=AggregatedKind.UNION,
+        switchType="test/t2_test_msgs/FooEnum",
+        definitions=[
+            MessageDefinitionField(type="int32", name="int_value", casePredicates=[0]),
+            MessageDefinitionField(
+                type="string", name="string_value", upperBound=32, casePredicates=[1]
+            ),
+        ],
+    )
+
+    root_def = MessageDefinition(
+        name="test/t2_test_msgs/msg/Bar",
+        definitions=[
+            MessageDefinitionField(
+                type="test/t2_test_msgs/FooUnion", name="union_value", isComplex=True
+            )
+        ],
+    )
+
+    # Ensure root struct comes before union definition for reader initialization
+    return [enum_def, root_def, union_def]
+
+
+def make_buffer():
+    writer = CdrWriter()
+    writer.uint32(1)  # discriminator ENUMERATOR2
+    writer.string("contains a string")
+    return writer.data
+
+
+def test_union_discriminator_as_int():
+    reader = MessageReader(make_defs())
+    msg = reader.read_message(make_buffer())
+    assert msg == {
+        "union_value": {
+            "discriminator": 1,
+            "string_value": "contains a string",
+        }
+    }
+
+
+def test_union_discriminator_as_string():
+    options = MessageReaderOptions(enumsAsStrings=True)
+    reader = MessageReader(make_defs(), options)
+    msg = reader.read_message(make_buffer())
+    assert msg == {
+        "union_value": {
+            "discriminator": "ENUMERATOR2",
+            "string_value": "contains a string",
+        }
+    }


### PR DESCRIPTION
## Summary
- add `enumsAsStrings` option and enum value mappings to MessageReader
- support converting enum fields, arrays, and union discriminators to named values
- test enum and union enum deserialization

## Testing
- `pre-commit run --files python_ros/rosmsg2_serialization/MessageReader.py python_ros/tests/test_message_reader_enum.py python_ros/tests/test_message_reader_union_enum.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899f1b0f97483309822246dc8013cd5